### PR TITLE
Documentation updates (fixes #21 #24)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,7 +103,7 @@ boardwalk/.env
 boardwalk/aws.config
 boardwalk/dcc-dashboard-service/
 boardwalk/dcc-dashboard/
-boardwalk/dcc-metadata-indexer/
+boardwalk/boardwalk/
 boardwalk_launcher_config/boardwalk.config
 
 aws.config

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# dcc-ops
+# cgp-deployment
 
 ## About
 
-This repository contains our Docker-compose and setup bootstrap scripts used to create a deployment of the [UCSC Genomic Institute's](http://ucsc-cgl.org) Computational Genomics Platform for AWS.  The system is designed to receive genomic data, run analysis at scale on the cloud, and return analyzed results to authorized users.  It uses, supports, and drives development of several key GA4GH APIs and open source projects. In many ways it is the generalization of the [PCAWG](https://dcc.icgc.org/pcawg) cloud infrastructure developed for that project and a potential reference implementation for the [NIH Commons](https://datascience.nih.gov/commons) concept.
+This repository contains our Docker-compose and setup bootstrap scripts used to create a deployment of the [UCSC Genomic Institute's](http://ucsc-cgl.org) Computational Genomics Platform for AWS. The system is designed to receive genomic data, run analysis at scale on the cloud, and return analyzed results to authorized users. It uses, supports, and drives development of several key GA4GH APIs and open source projects. In many ways it is the generalization of the [PCAWG](https://dcc.icgc.org/pcawg) cloud infrastructure developed for that project and a potential reference implementation for the [NIH Commons](https://datascience.nih.gov/commons) concept.
 
 ## Components
 
@@ -14,20 +14,18 @@ These components are setup with the install process available in this repository
 
 * [Boardwalk](boardwalk/README.md): our file browsing portal on top of Redwood
 
-These are related projects that are either already setup and available for use on the web or are used by components above.
+These are related projects that are either already setup and available for use on the web or are used by components above:
 
-* [Dockstore](http://dockstore.org): our workflow and tool sharing platform
+* [Dockstore](https://dockstore.org): our workflow and tool sharing platform
 * [Toil](https://github.com/BD2KGenomics/toil): our workflow engine, these workflows are shared via Dockstore
 
 ## Installing the Platform
 
-These directions below assume you are using AWS.  We will include additional cloud instructions as `dcc-ops` matures.
+These directions below assume you are using AWS.  We will include additional cloud instructions as `cgp-deployment` matures.
 
 ### Collecting Information
 
-Make sure you have:
-
-* you know what region you're running in e.g. `us-west-2`
+Make sure you know what region you're running in (e.g. `us-west-2`).
 
 ### Starting an AWS VM
 
@@ -37,11 +35,11 @@ Use the AWS console or command line tool to create a host. For example:
 * r4.xlarge
 * 250GB disk
 
-We will refer to this as the host VM throughout the documentation below and it is the machine running all the Docker containers for each of the components below.
+We will refer to this as the host VM throughout the rest of the documentation. It will run the Docker containers for all of the components listed below.
 
 You should make a note of your security group name and ID and ensure you can connect via ssh.
 
-**NOTE:** We have had problems when uploading big files to Virginia (~25GB). If possible, set up your AWS anywhere else but Virginia.
+**Note** We have had problems when uploading big files to Virginia (~25GB). If possible, set up your AWS anywhere else but Virginia.
 
 ### AWS Tasks
 
@@ -66,32 +64,17 @@ Add your private ssh key under `~/.ssh/<your_key>.pem`, this is typically the sa
 
 ### Setup for Boardwalk
 
-Here is a summary of what you need to do. See the Boardwalk [README](boardwalk/README.md) for details.
-
-#### Create a Google Oauth2 app
-
-You need to create a Google Oauth2 app to enable Login and token download from the dashboard. If you don't want to enable this on the dashboard during installation, simply enter a random string when asked for the *Google Client ID* and the *Google Client Secret*. You can consult [here](http://bitwiser.in/2015/09/09/add-google-login-in-flask.html#creating-a-google-project) under "Creating A Google Project" if you want to read more details. Here is a summary of what you need to do:
-
-* Go to [Google's Developer Console](https://console.developers.google.com/).
-* On the upper left side of the screen, click on the drop down button.
-* Create a project by clicking on the plus sign on the pop-up window.
-* On the next pop up window, add a name for your project.
-* Once you create it, click on the "Credentials" section on the left hand side.
-* Click on the "OAuth Consent Screen". Fill out a product name and choose an email for the Google Application. Fill the rest of the entries as you see fit for your purposes, or leave them blank, as they are optional. Save it.
-* Go to the "Credentials" tab. Click on the "Create Credentials" drop down menu and choose "OAuth Client ID".
-* Choose "Web Application" from the menu. Assign it a name.
-* Under "Authorized JavaScript origins", enter `http://<YOUR_SITE>`. Press Enter. Add a second entry, same as the first one, but use *https* instead of *http*
-* Under "Authorized redirect URIs", enter `http://<YOUR_SITE>/gCallback`. Press Enter. Add a second entry, same as the first one, but use *https* instead of *http*
-* Click "Create". A pop up window will appear with your Google Client ID and Google Client Secret. Save these. If you lose them, you can always go back to the Google Console, and click on your project; the information will be there.
-
-Please note: at this point, the dashboard only accepts login from emails with a 'ucsc.edu' domain. In the future, it will support different email domains.
+See the Boardwalk [README](boardwalk/README.md) for details.
 
 ### Running the Installer
 
-Once the above setup is done, clone this repository onto your server and run the bootstrap script
+Once the above setup is done, clone this repository onto your server and run the bootstrap script.
 
-    # note, you may need to checkout the particular branch or release tag you are interested in...
-    git clone https://github.com/BD2KGenomics/dcc-ops.git && cd dcc-ops && sudo bash install_bootstrap
+    $ git clone https://github.com/DataBiosphere/cgp-deployment.git
+    $ cd cgp-deployment
+    $ sudo bash install_bootstrap
+
+Remember to checkout the particular branch or release tag that you're interested in if it's necessary.
 
 #### Installer Question Notes
 
@@ -99,8 +82,6 @@ The `install_bootstrap` script will ask you to configure each service interactiv
 
 * Boardwalk
   * Install in prod mode
-  * On question `What is your Google Client ID?`, put your Google Client ID. See [here](http://bitwiser.in/2015/09/09/add-google-login-in-flask.html#creating-a-google-project)
-  * On question `What is your Google Client Secret?`, put your Google Client Secret. See [here](http://bitwiser.in/2015/09/09/add-google-login-in-flask.html#creating-a-google-project)
 * Common
   * Installing in `dev`mode will use letsencrypt's staging service, which won't exhaust your certificate's limit, but will install fake ssl certificates. `prod` mode will install official SSL certificates.  
   
@@ -116,7 +97,7 @@ Here are things we need to explain how to do post install:
 * first of all, how to go to the website and confirm things are working e.g. https://ops-dev.ucsc-cgl.org or whatever the domain name is
 * user log in via google, retrieve token
 * Get the reference data used by the RNASeq-CGL pipeline:
-*    Instructions for downloading reference data for RNASeq-CGL are located here: https://github.com/BD2KGenomics/toil-rnaseq/wiki/Pipeline-Inputs 
+*    Instructions for downloading reference data for RNASeq-CGL are located here: https://github.com/DataBiosphere/toil-rnaseq/wiki/Pipeline-Inputs 
 * Test data inputs for the RNASeq-CGL pipeline are locate here: https://github.com/UCSC-Treehouse/pipelines/tree/master/samples 
 * update the decider manually to point to these new reference URLs (via exec into the Docker container)
 * get sample fastq data
@@ -132,7 +113,7 @@ To test that everything installed successfully, you can run `cd test && ./integr
 
 ### Running RNA-Seq Analysis on Sample Data
 
-To do RNA-Seq Analysis, you must first upload reference files to Redwood. You can obtain the reference files by running from within dcc-ops:
+To do RNA-Seq Analysis, you must first upload reference files to Redwood. You can obtain the reference files by running from within cgp-deployment:
 
 ```
 reference/download_reference.sh
@@ -144,7 +125,7 @@ Once you have successfully uploaded the reference files, you can start submittin
 
 ### Troubleshooting
 
-If something goes wrong, you can [open an issue](https://github.com/BD2KGenomics/dcc-ops/issues/new) or [contact a human](https://github.com/BD2KGenomics/dcc-ops/graphs/contributors).
+If something goes wrong, you can [open an issue](https://github.com/DataBiosphere/cgp-deployment/issues/new) or [contact a human](https://github.com/DataBiosphere/cgp-deployment/graphs/contributors).
 
 ### Tips
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## About
 
-This repository contains our Docker-compose and setup bootstrap scripts used to create a deployment of the [UCSC Genomic Institute's](http://ucsc-cgl.org) Computational Genomics Platform for AWS. The system is designed to receive genomic data, run analysis at scale on the cloud, and return analyzed results to authorized users. It uses, supports, and drives development of several key GA4GH APIs and open source projects. In many ways it is the generalization of the [PCAWG](https://dcc.icgc.org/pcawg) cloud infrastructure developed for that project and a potential reference implementation for the [NIH Commons](https://datascience.nih.gov/commons) concept.
+This repository contains our Docker-compose and setup bootstrap scripts used to create a deployment of the [UCSC Genomic Institute's](http://ucsc-cgl.org) Computational Genomics Platform for AWS. It uses, supports, and drives development of several key GA4GH APIs and open source projects. In many ways it is the generalization of the [PCAWG](https://dcc.icgc.org/pcawg) cloud infrastructure developed for that project and a potential reference implementation for the [NIH Commons](https://datascience.nih.gov/commons) concept.
 
 ## Components
 
@@ -90,38 +90,9 @@ Once the installer completes, the system should be up and running. Congratulatio
 
 ## Post-Installation
 
-### TODO
-
-Here are things we need to explain how to do post install:
-
-* first of all, how to go to the website and confirm things are working e.g. https://ops-dev.ucsc-cgl.org or whatever the domain name is
-* user log in via google, retrieve token
-* Get the reference data used by the RNASeq-CGL pipeline:
-*    Instructions for downloading reference data for RNASeq-CGL are located here: https://github.com/DataBiosphere/toil-rnaseq/wiki/Pipeline-Inputs 
-* Test data inputs for the RNASeq-CGL pipeline are locate here: https://github.com/UCSC-Treehouse/pipelines/tree/master/samples 
-* update the decider manually to point to these new reference URLs (via exec into the Docker container)
-* get sample fastq data
-    * ...
-* upload sample fastq data
-* trigger indexing so you can immediately see fastq data in the file browser e.g. https://ops-dev.ucsc-cgl.org/file_browser.html, `sudo docker exec -it boardwalk_dcc-metadata-indexer_1 bash -c "/app/dcc-metadata-indexer/cron.sh"`
-* monitor running of Consonance logs and worker nodes to see running data
-* download RNASeq-CGL analysis results from the portal
-
 ### Confirm Proper Function
 
 To test that everything installed successfully, you can run `cd test && ./integration.sh`. This will do an upload and download with core-client and check the results.
-
-### Running RNA-Seq Analysis on Sample Data
-
-To do RNA-Seq Analysis, you must first upload reference files to Redwood. You can obtain the reference files by running from within cgp-deployment:
-
-```
-reference/download_reference.sh
-```
-
-This will download the files under `reference/samples`. You can then use the core client to do a spinnaker upload as described previously and use the _manifest.tsv_ within the `reference` folder. 
-
-Once you have successfully uploaded the reference files, you can start submitting fastq files to redwood to run analysis on them. See the help section on the file browser for more information on the template. Use `RNA-Seq` or `scRNA-Seq` when filling out the *Submitter Experimental Design* column on your manifest.
 
 ### Troubleshooting
 

--- a/boardwalk/README.md
+++ b/boardwalk/README.md
@@ -13,48 +13,35 @@ Deployment is done through the `install_bootstrap` script on the root directory.
 
 ### Create a Google Oauth2 app
 
-Before proceeding, you must ensure that you have a Google OAuth2 app. Follow the instructions on [here](http://bitwiser.in/2015/09/09/add-google-login-in-flask.html#creating-a-google-project) under "Creating A Google Project". 
+Before proceeding, you must ensure that you have a Google OAuth2 app. Follow the instructions [here](http://bitwiser.in/2015/09/09/add-google-login-in-flask.html#creating-a-google-project) under "Creating A Google Project". 
 
-If you don't want to enable Login and token retrieval through the portal, you can just put some random string for the Google Client ID and Google Client Secret. 
+If you don't want to enable login and token retrieval through the portal, you can just put some random string for the Google Client ID and Google Client Secret. 
 
 Here is a summary of what you need to do in order to create a Google OAuth2 app:
 
-* Go to [Google's Developer Console](https://console.developers.google.com/).
+* Go to the [Google Developer Console](https://console.developers.google.com/).
 * On the upper left side of the screen, click on the drop down button.
-* Create a project by clicking on the plus sign on the pop-up window.
-* On the next pop up window, add a name for your project. 
+* Create a project by clicking on the plus sign in the pop-up window.
+* On the next pop up window, add a name for your project.
 * Once you create it, click on the "Credentials" section on the left hand side.
 * Click on the "OAuth Consent Screen". Fill out a product name and choose an email for the Google Application. Fill the rest of the entries as you see fit for your purposes, or leave them blank, as they are optional. Save it.
 * Go to the "Credentials" tab. Click on the "Create Credentials" drop down menu and choose "OAuth Client ID".
-* Choose "Web Application" from the menu. Assign it a name. 
-* Under "Authorized JavaScript origins", enter `http://<YOUR_SITE>`. Press Enter. Add a second entry, same as the first one, but use *https* instead of *http*
-* Under "Authorized redirect URIs", enter `http://<YOUR_SITE>/gCallback`. Press Enter. Add a second entry, same as the first one, but use *https* instead of *http*
-* Click "Create". A pop up window will appear with your Google Client ID and Google Client Secret. Save these. If you lose them, you can always go back to the Google Console, and click on your project; the information will be there. Keep these values stored in a safe location. Treat them as you would treat a credit card number. 
+* Choose "Web Application" from the menu. Assign it a name.
+* Under "Authorized JavaScript origins", enter `http://<YOUR_SITE>`. Press Enter. Add a second entry, same as the first one, but use `https` instead of `http`.
+* Under "Authorized redirect URIs", enter `http://<YOUR_SITE>/gCallback`. Press Enter. Add a second entry, same as the first one, but use `https` instead of `http`.
+* Click "Create". A pop up window will appear with your Google Client ID and Google Client Secret. Save these. If you lose them, you can always go back to the Google Console, and click on your project; the information will be there. Keep these values stored in a safe location. Treat them as you would treat a credit card number.
 
-**Please note:** at this point, the dashboard only accepts login from emails with a 'ucsc.edu' domain. In the future, it will support different email domains. 
+**Note** at this point, the dashboard only accepts login from emails with a 'ucsc.edu' domain. In the future, it will support different email domains.
 
 ### Development Mode
 
-The boardwalk installer has the option to install boardwalk and its components in either devevelopment or production mode (dev/prod). If you are installing in production, skip this section and head to **Installation Questions**. Otherwise, keep reading.
+The boardwalk installer has the option to install boardwalk and its components in either development (dev) or production (prod) mode. If you are installing in production, skip this section and head to **Installation Questions**. Otherwise, keep reading.
 
 To make deployment during development faster, the `install_bootstrap` script will clone [cgp-dashboard](https://github.com/DataBiosphere/cgp-dashboard), [cgp-dashboard-service](https://github.com/DataBiosphere/cgp-dashboard-service), and [cgp-boardwalk](https://github.com/DataBiosphere/cgp-boardwalk) under `cgp-deployment/boardwalk/` if it looks like you haven't already done so. (If you're working off a non-default branch in one of those repos, you're going to want to do this yourself.)
 
-Once you run the installer, docker-compose will use dev.yml to set up boardwalk and its components. It will create the Docker images using the Dockerfiles located in each of the repositories listed above.
+Once you run the installer, `docker-compose` will use dev.yml to set up boardwalk and its components. It will create the Docker images using the Dockerfiles located in each of the repositories listed above.
 
 In addition, installing boardwalk in dev mode will also install kibana under `myexample.com/kibana/` to aid in debugging all things related to elasticsearch, as well as to help in making new queries and aggregations that may be necessary. 
-
-### Installation Questions
-* Choose a mode you want to run the installer (prod/dev). 
-* On question `What is your Google Client ID?`, put your Google Client ID. See [here](http://bitwiser.in/2015/09/09/add-google-login-in-flask.html#creating-a-google-project)
-* On question `What is your Google Client Secret?`, put your Google Client Secret. See [here](http://bitwiser.in/2015/09/09/add-google-login-in-flask.html#creating-a-google-project)
-* On question `What is your DCC Dashboard Host?`, put the domain name resolving to your Virtual Machine (e.g. `example.com`)
-* On question `What is the user and group that should own the files from the metadata-indexer?`, type the `USER:GROUP` pair you want the files downloaded by the indexer to be owned by. The question will show the current `USER:GROUP` pair for the current home directory. Highly recommended to type the same value in there (e.g. `1000:1000`)
-* On question `What is the AWS profile?`, type some random string (DEV, PROD)
-* On question `What is the AWS Access key ID?`, type some random string (DEV, PROD)
-* On question `What is the AWS secret access key?`, type some random string (DEV, PROD)
-* On question `What is the Postgres Database name for the action service?`, type the name to be assigned to the action service database.
-* On question `What is the Postgres Database user for the action service?`, type the username to be assigned to the the action service database.
-* On question `What is the Postgres Database password for the action service?`, type the password to be assigned to the action service database. 
 
 ### Checking Docker Containers
 

--- a/boardwalk/README.md
+++ b/boardwalk/README.md
@@ -27,11 +27,10 @@ Here is a summary of what you need to do in order to create a Google OAuth2 app:
 * Click on the "OAuth Consent Screen". Fill out a product name and choose an email for the Google Application. Fill the rest of the entries as you see fit for your purposes, or leave them blank, as they are optional. Save it.
 * Go to the "Credentials" tab. Click on the "Create Credentials" drop down menu and choose "OAuth Client ID".
 * Choose "Web Application" from the menu. Assign it a name.
-* Under "Authorized JavaScript origins", enter `http://<YOUR_SITE>`. Press Enter. Add a second entry, same as the first one, but use `https` instead of `http`.
-* Under "Authorized redirect URIs", enter `http://<YOUR_SITE>/gCallback`. Press Enter. Add a second entry, same as the first one, but use `https` instead of `http`.
+* Under "Authorized JavaScript origins", enter `https://<YOUR_SITE>`.
+* Under "Authorized redirect URIs", enter `https://<YOUR_SITE>/gCallback`.
 * Click "Create". A pop up window will appear with your Google Client ID and Google Client Secret. Save these. If you lose them, you can always go back to the Google Console, and click on your project; the information will be there. Keep these values stored in a safe location. Treat them as you would treat a credit card number.
 
-**Note** at this point, the dashboard only accepts login from emails with a 'ucsc.edu' domain. In the future, it will support different email domains.
 
 ### Development Mode
 

--- a/install_bootstrap
+++ b/install_bootstrap
@@ -19,7 +19,7 @@ UCSC CLOUD COMMONS INSTALLATION BOOTSTRAPPER
 -----------------------------------------------------------------------------
 This tool will setup a single host which has all of the infrastructure we
 use to run the UCSC Cloud Commons reference implemenation used by the
-UCSC Genomics Institute.  See https://github.com/DataBiosphere/dcc-ops
+UCSC Genomics Institute.  See https://github.com/DataBiosphere/cgp-deployment
 
 This system requires the following:
 * Docker support in your Linux distribution (Ubuntu 16.04 is officially supported).
@@ -31,7 +31,7 @@ ETH_DEV env variable before running this script.
 
 For more information see:
 
-* the main GitHub page: https://github.com/DataBiosphere/dcc-ops
+* the main GitHub page: https://github.com/DataBiosphere/cgp-deployment
 * the UCSC Genomics Institute - Analysis Core: http://ucsc-cgl.org
 
 MSG
@@ -249,7 +249,7 @@ while [[ "${run_boardwalk^^}" != 'Y' &&  "${run_boardwalk^^}" != 'N' ]] ; do
 #      fi
 
       dcc_dashboard_host='dcc_dashboard_host'
-      ask_question "What is the hostname of dcc-dashboard?" "$DCC_DASHBOARD_HOST" "DCC Dashboard Host" $dcc_dashboard_host
+      ask_question "What is the hostname of dcc-dashboard? (This is likely the domain name resolving to your virtual machine.)" "$DCC_DASHBOARD_HOST" "DCC Dashboard Host" $dcc_dashboard_host
         
       es_port='443'
       es_protocol='https'
@@ -291,8 +291,6 @@ while [[ "${run_boardwalk^^}" != 'Y' &&  "${run_boardwalk^^}" != 'N' ]] ; do
       dos_dss_service='dos_dss_service'
       ask_question "What is the domain of the dos-dss server?" "$DOS_DSS_SERVICE" "DOS DSS Service" $dos_dss_service
 
-      #user_group='user_group'
-      #ask_question "What is the user and group that should own the files from the metadata-indexer? (Your current USER:GROUP is $(stat -c '%u:%g' $HOME))" "$USER_GROUP" "User Group" $user_group
       user_group=$(stat -c '%u:%g' $HOME)
 
       #Setting up the database vars for login 

--- a/test/README.md
+++ b/test/README.md
@@ -1,5 +1,5 @@
 # test
-dcc-ops test suite
+cgp-deployment test suite
 
 # Overview
 The directory contains automated tests that can be run against an installation of the analysis core to confirm proper function.
@@ -8,6 +8,6 @@ For now, see `integration.sh`.
 
 ## Remove Docker images
 
-Execute the following to remove all running containers, volumes, and stopped images.  This is a potentially distructive process, if you have other non-dcc-ops containers/volumes/images on your machine please do not do this!
+Execute the following to remove all running containers, volumes, and stopped images.  This is a potentially distructive process, if you have other non-cgp-deployment containers/volumes/images on your machine please do not do this!
 
     sudo purge_docker.sh


### PR DESCRIPTION
- Remove some references to dcc-metadata-indexer
- Update links
- Remove redundant information
- `s/dcc-ops/cgp-deployment/g`
- Grammar fixes

Doesn't address other TODOs in the documentation.