### PR TITLE
Feature/update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,20 +29,27 @@ The installation script will prompt for several question. It is useful prepare f
 
 * make sure you know what region you're running in (e.g. `us-west-2`)
 * decide whether you want to create an instance for development or production as it might impact the size and therefore the cost of the host virtual machine
-* find out whether your host virtual machine will have you favorite editor installed
-* be sure to know how to create a static IP address for your virtual machine (AWS calls this _Elastic IP address_)
+* find out whether your favorite editor is installed on host virtual machine
+* be sure to know how to create a static IP address for your virtual machine (AWS calls this _Elastic IP_)
 * you will be asked to provide an host domain that points to your EC2 instance; at the time installation all you need is a name (i.e., the domain does not need to exist)
 * 
 
-### Starting an AWS VM
+### Launch an instance of a AWS EC2 virtual machine (VM)
 
-Use the AWS console or command line tool to create a host. For example:
+Use the AWS console or command line tool to create a host virtual machine. We will refer to this as the host VM throughout the rest of the documentation. Ultimately the performace and size of the VM depends on the traffic you expect. For example the following specification has worked well for a small-scale production environment:
 
 * Ubuntu Server 16.04
 * r4.xlarge
 * 250GB disk
 
-We will refer to this as the host VM throughout the rest of the documentation. It will run the Docker containers for all of the components listed below.
+In `prod` mode the installation will run the Docker containers for all of the components listed below.
+
+For development work the following specifications have worked well in the past:
+* Ubuntu Server 16.04
+* m5.xlarge
+* 80 GB disk
+
+In `dev` mode Docker containers will be built from source and the VM will run them during testing.
 
 You should make a note of your security group name and ID and ensure you can connect via ssh.
 
@@ -59,10 +66,18 @@ Make sure you do the following:
     * 443 <- world
     * all TCP <- the elastic IP of the VM (Make sure you add /32 to the Elastic IP)
     * all TCP <- the security group itself
+	
+The following security settings are recommended:
+
+| Command | Description |
+| --- | --- |
+| git status | List all new or modified files |
+| git diff | Show file differences that haven't been staged |
+
 
 #### Adding private SSH key to your VM
 
-Add your private ssh key under `~/.ssh/<your_key>.pem`, this is typically the same key that you use to SSH to your host VM, regardless it needs to be a key created on the AWS console so Amazon is aware of it. Then do `chmod 400 ~/.ssh/<your_key>.pem` so your key is not publicly viewable.
+Add your private ssh key under `~/.ssh/<your_key>.pem`, this is typically the same key that you use to SSH to your host VM, regardless it needs to be a key created on the AWS console so Amazon is aware of it. Then set privileges to _read-by-user-only_ by `chmod 400 ~/.ssh/<your_key>.pem` so your key is not publicly viewable.
 
 #### TODO:
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ For development work the following specifications have worked well in the past:
 * m5.large
 * 60 GB disk
 
-In `dev` mode Docker containers will be built from source and the VM will run them during testing. (see [here](https://github.com/DataBiosphere/cgp-deployment/blob/feature/update-readme/boardwalk/README.md#development-mode) for more details)
+In `dev` mode Docker containers will be built from source and the VM will run them during testing. (see [here](https://github.com/DataBiosphere/cgp-deployment/blob/feature/update-readme/boardwalk/README.md#development-mode) for more details). If work is planned only in *Boardwalk*, but not in common, and particularly if real certificates are needed during development, it is recommended to set up *Common* in `prod` mode, and *Boardwalk* in `dev` mode.
 
 
 #### Adding private SSH key to your VM

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ For development work the following specifications have worked well in the past:
 * m5.xlarge
 * 80 GB disk
 
-In `dev` mode Docker containers will be built from source and the VM will run them during testing. 
+In `dev` mode Docker containers will be built from source and the VM will run them during testing. (see [here](https://github.com/DataBiosphere/cgp-deployment/blob/feature/update-readme/boardwalk/README.md#development-mode) for more details)
 
 **Note:** We have had problems when uploading big files to Virginia (~25GB). If possible, set up your AWS anywhere else but Virginia.
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ For development work the following specifications have worked well in the past:
 * m5.xlarge
 * 80 GB disk
 
-In `dev` mode Docker containers will be built from source and the VM will run them during testing. You should make a note of your security group name and ID and ensure you can connect via ssh.
+In `dev` mode Docker containers will be built from source and the VM will run them during testing. You should make a note of your security group name and ID and ensure you can [connect via ssh](#makeip).
 
 **Note:** We have had problems when uploading big files to Virginia (~25GB). If possible, set up your AWS anywhere else but Virginia.
 

--- a/README.md
+++ b/README.md
@@ -58,16 +58,14 @@ For development work the following specifications have worked well in the past:
 * m5.xlarge
 * 80 GB disk
 
-In `dev` mode Docker containers will be built from source and the VM will run them during testing.
+In `dev` mode Docker containers will be built from source and the VM will run them during testing. You should make a note of your security group name and ID and ensure you can connect via ssh.
 
-You should make a note of your security group name and ID and ensure you can connect via ssh.
-
-**Note** We have had problems when uploading big files to Virginia (~25GB). If possible, set up your AWS anywhere else but Virginia.
+**Note:** We have had problems when uploading big files to Virginia (~25GB). If possible, set up your AWS anywhere else but Virginia.
 
 ### AWS Tasks
 
-1. Assign an \textit{Elastic IP} (a static IP address) to your instance [as described here](#makeip).
-2. Open inbound ports on your security group. Use the table below as a guide. Make sure you add /32 to the Elastic IP.
+1. Assign an *Elastic IP* (a static IP address) to your instance [as described here](#makeip).
+2. Open inbound ports on your security group. Use the table below as a guide. Make sure you add /32 to the *Elastic IP*.
 
 | Type | Port | Source | Description |
 | --- | --- | --- | --- |

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ For development work the following specifications have worked well in the past:
 * m5.large
 * 60 GB disk
 
-In `dev` mode Docker containers will be built from source and the VM will run them during testing. (see [here](https://github.com/DataBiosphere/cgp-deployment/blob/feature/update-readme/boardwalk/README.md#development-mode) for more details). If work is planned only in *Boardwalk*, but not in common, and particularly if real certificates are needed during development, it is recommended to set up *Common* in `prod` mode, and *Boardwalk* in `dev` mode.
+In `dev` mode Docker containers will be built from source and the VM will run them during testing. (see [here](https://github.com/DataBiosphere/cgp-deployment/blob/feature/update-readme/boardwalk/README.md#development-mode) for more details). If work is planned only in *Boardwalk*, but not in *Common*, and particularly if real certificates are needed during development, it is recommended to set up *Common* in `prod` mode, and *Boardwalk* in `dev` mode.
 
 
 #### Adding private SSH key to your VM

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The installation script will prompt for several questions. It is useful to prepa
 * create a static IP address for your virtual machine (AWS calls this _Elastic IP_); find a short set of instructions below
 * you will be asked to provide an host domain that points to your EC2 instance; at the time of installation that domain (or _record set_) does not have to be configured in _Route 53_.
 
-#### Create an _Elastic IP_ for your VM
+#### <a name="makeip"></a>Create an _Elastic IP_ for your VM 
 1. Go to _AWS console_, _Compute_,  _EC2 Dashboard_. There click *running instances*. 
 2. Find your VM and make it active by clicking anywhere in that line.
 3. Under the drop-down *Actions*, go to *Networking*, *Manage IP Addreses*.
@@ -66,7 +66,7 @@ You should make a note of your security group name and ID and ensure you can con
 
 ### AWS Tasks
 
-1. Assign an Elastic IP (a static IP address) to your instance.
+1. Assign an \textit{Elastic IP} (a static IP address) to your instance [as described here](#makeip).
 2. Open inbound ports on your security group. Use the table below as a guide. Make sure you add /32 to the Elastic IP.
 
 | Type | Port | Source | Description |

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Once the above setup is done, clone this repository onto your server and run the
     $ cd cgp-deployment
     $ sudo bash install_bootstrap
 
-The `install_bootstrap` script will ask you to configure each service interactively. Specifically, you need to decide on whether you require a production (`prod` mode) or a development (`dev` mode) environment. Note that this decision can be made for _Common_ and _Boardwalk_ independently.
+The `install_bootstrap` script will ask you to configure each service interactively. Specifically, you need to decide on whether you require a production (`prod` mode) or a development (`dev` mode) environment. Note that this decision can be made for _Common_ and _Boardwalk_ independently. For details regarding _Boardwalk_ see the [README](boardwalk/README.md).
 
 #### Installing in `prod` mode
 Once the above steps have been completed we are now ready to install the components of the CGP.
@@ -103,16 +103,6 @@ In `prod` mode the installation will run the Docker containers for all of the co
 Setting up *Common* to run in `dev` mode will cause [Let's Encrypt](https://letsencrypt.org/) to issue fake SSL certificates, which won't exhaust your certificate's limit. Setting up *Boardwalk* to run in `dev` mode will first build then run the Docker containers `boardwalk_nginx`, `boardwalk_dcc-dashboard`, `boardwalk_dcc-dashboard-service`, and `boardwalk_boardwalk` from the images (see [here](https://github.com/DataBiosphere/cgp-deployment/blob/feature/update-readme/boardwalk/README.md#development-mode) for more details). In addition, the `nginx` image is built from the *nginx-dev* directory. If your work requires real SSL certificates during development, it is recommended to set up *Common* in `prod` mode, and *Boardwalk* in `dev` mode.
   
 Once the installer completes, the system should be up and running. Congratulations! Execute `docker ps` to get an idea of which containers are running.
-
-#### TODO:
-
-* Guide on choosing AWS instance type... make sure it matches your AMI.
-* AMI, use an ubuntu 16.04 base box, you can use the official Ubuntu release. You may need to make your own AMI with more storage! Needs to be in your region!  You may want to google to start with the official Ubuntu images for your region.
-
-### Setup for Boardwalk
-
-See the Boardwalk [README](boardwalk/README.md) for details.
-
 
 
 ## Post-Installation

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The installation script will prompt for several question. It is useful prepare f
 
 ### Launch an instance of a AWS EC2 virtual machine (VM)
 
-Use the AWS console or command line tool to create a host virtual machine. We will refer to this as the host VM throughout the rest of the documentation. Ultimately the performace and size of the VM depends on the traffic you expect. For example the following specification has worked well for a small-scale production environment:
+Use the AWS console or command line tool to create a host virtual machine. We will refer to this machine as the VM throughout the rest of the documentation. Ultimately the performace and size of the VM depends on the traffic you expect. For example the following specification has worked well for a small-scale production environment:
 
 * Ubuntu Server 16.04
 * r4.xlarge

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ For development work the following specifications have worked well in the past:
 * m5.large
 * 60 GB disk
 
-In `dev` mode Docker containers will be built from source and the VM will run them during testing. (see [here](https://github.com/DataBiosphere/cgp-deployment/blob/feature/update-readme/boardwalk/README.md#development-mode) for more details). If work is planned only in *Boardwalk*, but not in *Common*, and particularly if real certificates are needed during development, it is recommended to set up *Common* in `prod` mode, and *Boardwalk* in `dev` mode.
+Setting up *Common* in `dev` mode will cause [Let's Encrypt](https://letsencrypt.org/) to issue fake SSL certificates. Setting up *Boardwalk* in `dev` mode will cause the Docker containers `boardwalk_nginx`, `boardwalk_dcc-dashboard`, `boardwalk_dcc-dashboard-service`, and `boardwalk_boardwalk` to be built from source (see [here](https://github.com/DataBiosphere/cgp-deployment/blob/feature/update-readme/boardwalk/README.md#development-mode) for more details). If your work requires real SSL certificates during development, it is recommended to set up *Common* in `prod` mode, and *Boardwalk* in `dev` mode.
 
 
 #### Adding private SSH key to your VM

--- a/README.md
+++ b/README.md
@@ -76,13 +76,13 @@ These directions below assume you are using AWS.  We will include additional clo
 
 ### Collecting Information
 
-The installation script will prompt for several questions. It is useful to prepare for some of the answers beforehand to expedite the installation process. Here are a few pointers:
+The installation script (`install_bootstrap`) will prompt for several questions. It is useful to prepare for some of the answers beforehand to expedite the installation process. Here are a few pointers:
 
-* make sure you know what region you're running in (e.g. `us-west-2`)
-* decide whether you want to create an instance for development or production as it might impact the size and therefore the cost of the host virtual machine
-* find out whether your favorite editor is installed on host virtual machine
-* create a static IP address for your virtual machine (AWS calls this _Elastic IP_); find a short set of instructions below
-* you will be asked to provide an host domain that points to your EC2 instance; at the time of installation that domain (or _record set_) does not have to be configured in _Route 53_.
+* make sure you know what AWS region your VM runs in (e.g. `us-west-2`)
+* decide whether you want to create an instance for development or production as it might impact the size and therefore the cost of the host virtual machine (see above for recommendations)
+* find out whether your favorite editor is installed on the VM
+* create a static IP address for your VM (AWS calls this _Elastic IP_); find a short set of instructions above
+* you will be asked to provide an host domain that points to your EC2 instance; you need to know the name of the domain but at the time of installation the domain (or _record set_) does not have to be configured in _Route 53_
 
 ### Running the Installer
 
@@ -92,7 +92,7 @@ Once the above setup is done, clone this repository onto your server and run the
     $ cd cgp-deployment
     $ sudo bash install_bootstrap
 
-The `install_bootstrap` script will ask you to configure each service interactively. Specifically, you need to decide on whether you require a production (`prod` mode) or a development (`dev` mode) environment.
+The `install_bootstrap` script will ask you to configure each service interactively. Specifically, you need to decide on whether you require a production (`prod` mode) or a development (`dev` mode) environment. Note that this decision can be made for _Common_ and _Boardwalk_ independently.
 
 #### Installing in `prod` mode
 Once the above steps have been completed we are now ready to install the components of the CGP.
@@ -102,12 +102,12 @@ In `prod` mode the installation will run the Docker containers for all of the co
 #### Installing in `dev` mode
 Setting up *Common* to run in `dev` mode will cause [Let's Encrypt](https://letsencrypt.org/) to issue fake SSL certificates, which won't exhaust your certificate's limit. Setting up *Boardwalk* to run in `dev` mode will first build then run the Docker containers `boardwalk_nginx`, `boardwalk_dcc-dashboard`, `boardwalk_dcc-dashboard-service`, and `boardwalk_boardwalk` from the images (see [here](https://github.com/DataBiosphere/cgp-deployment/blob/feature/update-readme/boardwalk/README.md#development-mode) for more details). In addition, the `nginx` image is built from the *nginx-dev* directory. If your work requires real SSL certificates during development, it is recommended to set up *Common* in `prod` mode, and *Boardwalk* in `dev` mode.
   
-Once the installer completes, the system should be up and running. Congratulations! See `docker ps` to get an idea of what's running.
+Once the installer completes, the system should be up and running. Congratulations! Execute `docker ps` to get an idea of which containers are running.
 
 #### TODO:
 
 * Guide on choosing AWS instance type... make sure it matches your AMI.
-* AMI, use an ubuntu 16.04 base box, you can use the official Ubuntu release.  You may need to make your own AMI with more storage! Needs to be in your region!  You may want to google to start with the official Ubuntu images for your region.
+* AMI, use an ubuntu 16.04 base box, you can use the official Ubuntu release. You may need to make your own AMI with more storage! Needs to be in your region!  You may want to google to start with the official Ubuntu images for your region.
 
 ### Setup for Boardwalk
 

--- a/README.md
+++ b/README.md
@@ -41,14 +41,14 @@ Use the AWS console or command line tool to create a host virtual machine. While
 * r4.xlarge
 * 250GB disk
 
-In `prod` mode the installation will run the Docker containers for all of the components listed below.
+In `prod` mode the installation will run the Docker containers for all of the components listed below from the respective images from *Quay.io*.
 
 For development work the following specifications have worked well in the past:
 * Ubuntu Server 16.04
 * m5.large
 * 60 GB disk
 
-Setting up *Common* to run in `dev` mode will cause [Let's Encrypt](https://letsencrypt.org/) to issue fake SSL certificates. Setting up *Boardwalk* to run in `dev` mode will enable the option to instantiate the Docker containers `boardwalk_nginx`, `boardwalk_dcc-dashboard`, `boardwalk_dcc-dashboard-service`, and `boardwalk_boardwalk` from the images (see [here](https://github.com/DataBiosphere/cgp-deployment/blob/feature/update-readme/boardwalk/README.md#development-mode) for more details). If your work requires real SSL certificates during development, it is recommended to set up *Common* in `prod` mode, and *Boardwalk* in `dev` mode.
+Setting up *Common* to run in `dev` mode will cause [Let's Encrypt](https://letsencrypt.org/) to issue fake SSL certificates. Setting up *Boardwalk* to run in `dev` mode will first build then run the Docker containers `boardwalk_nginx`, `boardwalk_dcc-dashboard`, `boardwalk_dcc-dashboard-service`, and `boardwalk_boardwalk` from the images (see [here](https://github.com/DataBiosphere/cgp-deployment/blob/feature/update-readme/boardwalk/README.md#development-mode) for more details). If your work requires real SSL certificates during development, it is recommended to set up *Common* in `prod` mode, and *Boardwalk* in `dev` mode.
 
 
 #### <a name="makeip"></a>Create and assign an _Elastic IP_ for your VM 

--- a/README.md
+++ b/README.md
@@ -69,10 +69,17 @@ Make sure you do the following:
 	
 The following security settings are recommended:
 
-| Command | Description |
-| --- | --- |
-| git status | List all new or modified files |
-| git diff | Show file differences that haven't been staged |
+| Type | Port | Source | Description |
+| --- | --- | --- | --- |
+| HTTP | 80 | 0.0.0.0/0 | |
+| HTTP | 80 | ::/0 | |
+| HTTPS | 443 | 0.0.0.0/0 | |
+| HTTPS | 443 | ::/0 | |
+| All TCP | 0 - 65535 | _VM's Elastic IP_ | |
+| All TCP | 0 = 65535 | _Your Security Group ID_ | | 
+| Custom TCP Rule | 9000 | _VM's Elastic IP_ | webservice port |
+| Custom TCP Rule | 9200 | _VM's Elastic IP_ | Elasticsearch |
+| SSH | 22 | 0.0.0.0/0 | |
 
 
 #### Adding private SSH key to your VM

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The installation script will prompt for several questions. It is useful to prepa
 
 ### Launch an instance of a AWS EC2 virtual machine (VM)
 
-Use the AWS console or command line tool to create a host virtual machine. While you do this make a note of your security group name and ID and ensure you can [connect via ssh](#makeip). We will refer to this virtual machine as the VM throughout the rest of the documentation. Ultimately the performance and size of the VM depends on the traffic you expect. For example the following specification has worked well for a small-scale production environment:
+Use the AWS console or command line tool to create a host virtual machine. While you do this make a note of your security group name and ID and ensure you can [connect via ssh](#sshconnect). We will refer to this virtual machine as the VM throughout the rest of the documentation. Ultimately the performance and size of the VM depends on the traffic you expect. For example the following specification has worked well for a small-scale production environment:
 
 * Ubuntu Server 16.04
 * r4.xlarge
@@ -64,7 +64,7 @@ Add your private ssh key under `~/.ssh/<your_key>.pem`, this is typically the sa
 4. Click on *Allocate an Elastic IP*. It will automatically create an IP address and show it on the screen.
 5. Write down that _Elastic IP_. At this point, whatever IP address is shown under IPv4 Public IP for your VM is not the current instance's IP address. Next you need to associate the _Elastic IP_ with your VM.
 6. Back in _EC2 Dashboard_ go to *Elastic IPs*. The IP address just created should be in that list. Check it and under *Actions*, *Associate*, choose resource type "Instance", and choose your EC2 (e.g., searching by its name).
-7. In _EC2 Dashboard_ make your VM active by clicking it. Then click _Connect_ on top. The example in that window shows you how to ssh into your VM from a terminal.
+7.  <a name="sshconnect"></a>In _EC2 Dashboard_ make your VM active by clicking it. Then click _Connect_ on top. The example in that window shows you how to ssh into your VM from a terminal.
 
 
 #### Configuring the ports in your VM
@@ -109,7 +109,7 @@ The `install_bootstrap` script will ask you to configure each service interactiv
 * Boardwalk
   * Install in prod mode
 * Common
-  * Installing in `dev`mode will use letsencrypt's staging service, which won't exhaust your certificate's limit, but will install fake ssl certificates. `prod` mode will install official SSL certificates.  
+  * Installing in `dev`mode will use letsencrypt's staging service, which won't exhaust your certificate's limit, but will install fake ssl certificates. `prod` mode will install official SSL certificates.
   
   
 Once the installer completes, the system should be up and running. Congratulations! See `docker ps` to get an idea of what's running.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## About
 
-This repository contains our Docker-compose and setup bootstrap scripts used to create a deployment of the [UCSC Genomic Institute's](http://ucsc-cgl.org) Computational Genomics Platform for AWS. It uses, supports, and drives development of several key GA4GH APIs and open source projects. In many ways it is the generalization of the [PCAWG](https://dcc.icgc.org/pcawg) cloud infrastructure developed for that project and a potential reference implementation for the [NIH Commons](https://datascience.nih.gov/commons) concept.
+This repository contains our Docker-compose and setup bootstrap scripts used to create a deployment of the [UCSC Genomic Institute's](http://ucsc-cgl.org) Computational Genomics Platform (CGP) for AWS. It uses, supports, and drives development of several key GA4GH APIs and open source projects. In many ways it is the generalization of the [PCAWG](https://dcc.icgc.org/pcawg) cloud infrastructure developed for that project and a potential reference implementation for the [NIH Commons](https://datascience.nih.gov/commons) concept.
 
 ## Components
 
@@ -69,7 +69,7 @@ Add your private ssh key under `~/.ssh/<your_key>.pem`, this is typically the sa
 
 
 #### Installing in `prod` mode
-As an example the following specification has worked well for a small-scale production environment :
+Once the above steps have been completed we are now ready to install the components of the CGP. As an example the following specification has worked well for a small-scale production environment :
 
 * Ubuntu Server 16.04
 * r4.xlarge

--- a/README.md
+++ b/README.md
@@ -51,11 +51,6 @@ For development work the following specifications have worked well in the past:
 Setting up *Common* in `dev` mode will cause [Let's Encrypt](https://letsencrypt.org/) to issue fake SSL certificates. Setting up *Boardwalk* in `dev` mode will cause the Docker containers `boardwalk_nginx`, `boardwalk_dcc-dashboard`, `boardwalk_dcc-dashboard-service`, and `boardwalk_boardwalk` to be built from source (see [here](https://github.com/DataBiosphere/cgp-deployment/blob/feature/update-readme/boardwalk/README.md#development-mode) for more details). If your work requires real SSL certificates during development, it is recommended to set up *Common* in `prod` mode, and *Boardwalk* in `dev` mode.
 
 
-#### Adding private SSH key to your VM
-
-Add your private ssh key under `~/.ssh/<your_key>.pem`, this is typically the same key that you use to SSH to your host VM, regardless it needs to be a key created on the AWS console so Amazon is aware of it. Then set privileges to _read-by-user-only_ by `chmod 400 ~/.ssh/<your_key>.pem` so your key is not publicly viewable.
-
-
 #### <a name="makeip"></a>Create and assign an _Elastic IP_ for your VM 
 1. Go to _AWS console_, _Compute_,  _EC2 Dashboard_. There click *running instances*. 
 2. Find your VM and make it active by clicking anywhere in that line.
@@ -65,6 +60,10 @@ Add your private ssh key under `~/.ssh/<your_key>.pem`, this is typically the sa
 6. Back in _EC2 Dashboard_ go to *Elastic IPs*. The IP address just created should be in that list. Check it and under *Actions*, *Associate*, choose resource type "Instance", and choose your EC2 (e.g., searching by its name).
 7.  <a name="sshconnect"></a>In _EC2 Dashboard_ make your VM active by clicking it. Then click _Connect_ on top. The example in that window shows you how to ssh into your VM from a terminal.
 
+
+#### Adding private SSH key to your VM
+
+Add your private ssh key under `~/.ssh/<your_key>.pem`, this is typically the same key that you use to SSH to your host VM, regardless it needs to be a key created on the AWS console so Amazon is aware of it. Then set privileges to _read-by-user-only_ by `chmod 400 ~/.ssh/<your_key>.pem` so your key is not publicly viewable.
 
 #### Configuring the ports in your VM
 Open inbound ports on your security group. Use the table below as a guide. Make sure you add /32 to the *Elastic IP*.

--- a/README.md
+++ b/README.md
@@ -76,13 +76,16 @@ These directions below assume you are using AWS.  We will include additional clo
 
 ### Collecting Information
 
-The installation script (`install_bootstrap`) will prompt for several questions. It is useful to prepare for some of the answers beforehand to expedite the installation process. Here are a few pointers:
+The installation script (`install_bootstrap`) will prompt for several questions. To expedite the installation process it is useful to prepare for some of the answers beforehand. Here are a few pointers:
 
 * make sure you know what AWS region your VM runs in (e.g. `us-west-2`)
 * decide whether you want to create an instance for development or production as it might impact the size and therefore the cost of the host virtual machine (see above for recommendations)
 * find out whether your favorite editor is installed on the VM
 * create a static IP address for your VM (AWS calls this _Elastic IP_); find a short set of instructions above
 * you will be asked to provide an host domain that points to your EC2 instance; you need to know the name of the domain but at the time of installation the domain (or _record set_) does not have to be configured in _Route 53_
+* _Boardwalk_ has functionality to export metadata to Broad's FireCloud; in order to use it you need to provide your Google Cloud Platform credentials; specifically you need the Google Client ID and the Google Client Secret (it's okay to leave the Google site verfication code empty)
+* all metadata reside in an Elasticsearch database; make sure you have the domain name of that Elasticsearch instance handy
+* have the domain name of the _dos-dss server_ handy
 
 ### Running the Installer
 

--- a/README.md
+++ b/README.md
@@ -33,19 +33,9 @@ The installation script will prompt for several questions. It is useful to prepa
 * create a static IP address for your virtual machine (AWS calls this _Elastic IP_); find a short set of instructions below
 * you will be asked to provide an host domain that points to your EC2 instance; at the time of installation that domain (or _record set_) does not have to be configured in _Route 53_.
 
-#### <a name="makeip"></a>Create an _Elastic IP_ for your VM 
-1. Go to _AWS console_, _Compute_,  _EC2 Dashboard_. There click *running instances*. 
-2. Find your VM and make it active by clicking anywhere in that line.
-3. Under the drop-down *Actions*, go to *Networking*, *Manage IP Addreses*.
-4. Click on *Allocate an Elastic IP*. It will automatically create an IP address and show it on the screen.
-5. Write down that _Elastic IP_. At this point, whatever IP address is shown under IPv4 Public IP for your VM is not the current instance's IP address. Next you need to associate the _Elastic IP_ with your VM.
-6. Back in _EC2 Dashboard_ go to *Elastic IPs*. The IP address just created should be in that list. Check it and under *Actions*, *Associate*, choose resource type "Instance", and choose your EC2 (e.g., searching by its name).
-7. In _EC2 Dashboard_ make your VM active by clicking it. Then click _Connect_ on top. The example in that window shows you how to ssh into your VM from a terminal.
-
-
 ### Launch an instance of a AWS EC2 virtual machine (VM)
 
-Use the AWS console or command line tool to create a host virtual machine. We will refer to this machine as the VM throughout the rest of the documentation. Ultimately the performance and size of the VM depends on the traffic you expect. For example the following specification has worked well for a small-scale production environment:
+Use the AWS console or command line tool to create a host virtual machine. While you do this make a note of your security group name and ID and ensure you can [connect via ssh](#makeip). We will refer to this virtual machine as the VM throughout the rest of the documentation. Ultimately the performance and size of the VM depends on the traffic you expect. For example the following specification has worked well for a small-scale production environment:
 
 * Ubuntu Server 16.04
 * r4.xlarge
@@ -58,14 +48,27 @@ For development work the following specifications have worked well in the past:
 * m5.xlarge
 * 80 GB disk
 
-In `dev` mode Docker containers will be built from source and the VM will run them during testing. You should make a note of your security group name and ID and ensure you can [connect via ssh](#makeip).
+In `dev` mode Docker containers will be built from source and the VM will run them during testing. 
 
 **Note:** We have had problems when uploading big files to Virginia (~25GB). If possible, set up your AWS anywhere else but Virginia.
 
-### AWS Tasks
+#### Adding private SSH key to your VM
 
-1. Assign an *Elastic IP* (a static IP address) to your instance [as described here](#makeip).
-2. Open inbound ports on your security group. Use the table below as a guide. Make sure you add /32 to the *Elastic IP*.
+Add your private ssh key under `~/.ssh/<your_key>.pem`, this is typically the same key that you use to SSH to your host VM, regardless it needs to be a key created on the AWS console so Amazon is aware of it. Then set privileges to _read-by-user-only_ by `chmod 400 ~/.ssh/<your_key>.pem` so your key is not publicly viewable.
+
+
+#### <a name="makeip"></a>Create and assign an _Elastic IP_ for your VM 
+1. Go to _AWS console_, _Compute_,  _EC2 Dashboard_. There click *running instances*. 
+2. Find your VM and make it active by clicking anywhere in that line.
+3. Under the drop-down *Actions*, go to *Networking*, *Manage IP Addreses*.
+4. Click on *Allocate an Elastic IP*. It will automatically create an IP address and show it on the screen.
+5. Write down that _Elastic IP_. At this point, whatever IP address is shown under IPv4 Public IP for your VM is not the current instance's IP address. Next you need to associate the _Elastic IP_ with your VM.
+6. Back in _EC2 Dashboard_ go to *Elastic IPs*. The IP address just created should be in that list. Check it and under *Actions*, *Associate*, choose resource type "Instance", and choose your EC2 (e.g., searching by its name).
+7. In _EC2 Dashboard_ make your VM active by clicking it. Then click _Connect_ on top. The example in that window shows you how to ssh into your VM from a terminal.
+
+
+#### Configuring the ports in your VM
+Open inbound ports on your security group. Use the table below as a guide. Make sure you add /32 to the *Elastic IP*.
 
 | Type | Port | Source | Description |
 | --- | --- | --- | --- |
@@ -79,10 +82,6 @@ In `dev` mode Docker containers will be built from source and the VM will run th
 | Custom TCP Rule | 9200 | _Your VM's Elastic IP_ | Elasticsearch |
 | SSH | 22 | 0.0.0.0/0 | |
 
-
-#### Adding private SSH key to your VM
-
-Add your private ssh key under `~/.ssh/<your_key>.pem`, this is typically the same key that you use to SSH to your host VM, regardless it needs to be a key created on the AWS console so Amazon is aware of it. Then set privileges to _read-by-user-only_ by `chmod 400 ~/.ssh/<your_key>.pem` so your key is not publicly viewable.
 
 #### TODO:
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ For development work the following specifications have worked well in the past:
 * m5.large
 * 60 GB disk
 
-Setting up *Common* in `dev` mode will cause [Let's Encrypt](https://letsencrypt.org/) to issue fake SSL certificates. Setting up *Boardwalk* in `dev` mode will cause the Docker containers `boardwalk_nginx`, `boardwalk_dcc-dashboard`, `boardwalk_dcc-dashboard-service`, and `boardwalk_boardwalk` to be built from source (see [here](https://github.com/DataBiosphere/cgp-deployment/blob/feature/update-readme/boardwalk/README.md#development-mode) for more details). If your work requires real SSL certificates during development, it is recommended to set up *Common* in `prod` mode, and *Boardwalk* in `dev` mode.
+Setting up *Common* to run in `dev` mode will cause [Let's Encrypt](https://letsencrypt.org/) to issue fake SSL certificates. Setting up *Boardwalk* to run in `dev` mode will cause the Docker containers `boardwalk_nginx`, `boardwalk_dcc-dashboard`, `boardwalk_dcc-dashboard-service`, and `boardwalk_boardwalk` to be built from source (see [here](https://github.com/DataBiosphere/cgp-deployment/blob/feature/update-readme/boardwalk/README.md#development-mode) for more details). If your work requires real SSL certificates during development, it is recommended to set up *Common* in `prod` mode, and *Boardwalk* in `dev` mode.
 
 
 #### <a name="makeip"></a>Create and assign an _Elastic IP_ for your VM 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,14 @@ These directions below assume you are using AWS.  We will include additional clo
 
 ### Collecting Information
 
-Make sure you know what region you're running in (e.g. `us-west-2`).
+The installation script will prompt for several question. It is useful prepare for some of the answers beforehand to expedite the installation process. Here are a few pointers:
+
+* make sure you know what region you're running in (e.g. `us-west-2`)
+* decide whether you want to create an instance for development or production as it might impact the size and therefore the cost of the host virtual machine
+* find out whether your host virtual machine will have you favorite editor installed
+* be sure to know how to create a static IP address for your virtual machine (AWS calls this _Elastic IP address_)
+* you will be asked to provide an host domain that points to your EC2 instance; at the time installation all you need is a name (i.e., the domain does not need to exist)
+* 
 
 ### Starting an AWS VM
 

--- a/README.md
+++ b/README.md
@@ -57,17 +57,8 @@ You should make a note of your security group name and ID and ensure you can con
 
 ### AWS Tasks
 
-Make sure you do the following:
-
-* assign an Elastic IP (a static IP address) to your instance
-* open inbound ports on your security group
-    * 80 <- world
-    * 22 <- world
-    * 443 <- world
-    * all TCP <- the elastic IP of the VM (Make sure you add /32 to the Elastic IP)
-    * all TCP <- the security group itself
-	
-The following security settings are recommended:
+1. Assign an Elastic IP (a static IP address) to your instance.
+2. Open inbound ports on your security group. Use the table below as a guide. Make sure you add /32 to the Elastic IP.
 
 | Type | Port | Source | Description |
 | --- | --- | --- | --- |
@@ -75,10 +66,10 @@ The following security settings are recommended:
 | HTTP | 80 | ::/0 | |
 | HTTPS | 443 | 0.0.0.0/0 | |
 | HTTPS | 443 | ::/0 | |
-| All TCP | 0 - 65535 | _VM's Elastic IP_ | |
-| All TCP | 0 = 65535 | _Your Security Group ID_ | | 
-| Custom TCP Rule | 9000 | _VM's Elastic IP_ | webservice port |
-| Custom TCP Rule | 9200 | _VM's Elastic IP_ | Elasticsearch |
+| All TCP | 0 - 65535 | _Your VM's Elastic IP_ | |
+| All TCP | 0 - 65535 | _Your Security Group ID_ | | 
+| Custom TCP Rule | 9000 | _Your VM's Elastic IP_ | webservice port |
+| Custom TCP Rule | 9200 | _Your VM's Elastic IP_ | Elasticsearch |
 | SSH | 22 | 0.0.0.0/0 | |
 
 

--- a/README.md
+++ b/README.md
@@ -19,23 +19,24 @@ These are related projects that are either already setup and available for use o
 * [Dockstore](https://dockstore.org): our workflow and tool sharing platform
 * [Toil](https://github.com/BD2KGenomics/toil): our workflow engine, these workflows are shared via Dockstore
 
-## Installing the Platform
 
-These directions below assume you are using AWS.  We will include additional cloud instructions as `cgp-deployment` matures.
 
-### Collecting Information
-
-The installation script will prompt for several questions. It is useful to prepare for some of the answers beforehand to expedite the installation process. Here are a few pointers:
-
-* make sure you know what region you're running in (e.g. `us-west-2`)
-* decide whether you want to create an instance for development or production as it might impact the size and therefore the cost of the host virtual machine
-* find out whether your favorite editor is installed on host virtual machine
-* create a static IP address for your virtual machine (AWS calls this _Elastic IP_); find a short set of instructions below
-* you will be asked to provide an host domain that points to your EC2 instance; at the time of installation that domain (or _record set_) does not have to be configured in _Route 53_.
 
 ### Launch an instance of a AWS EC2 virtual machine (VM)
 
 Use the AWS console or command line tool to create a host virtual machine. While you do this make a note of your security group name and ID and ensure you can [connect via ssh](#sshconnect). We will refer to this virtual machine as the VM throughout the rest of the documentation. Ultimately the performance and size of the VM depends on the traffic you expect. (**Note:** We have had problems when uploading big files to Virginia (~25GB). If possible, set up your AWS anywhere else but Virginia.)
+
+The following specification has worked well for a small-scale production environment :
+
+* Ubuntu Server 16.04
+* r4.xlarge
+* 250GB disk
+
+For development work the following specifications have worked well in the past:
+* Ubuntu Server 16.04
+* m5.large
+* 60 GB disk
+
 
 #### Configuring the ports in your VM
 Open inbound ports on your security group. Use the table below as a guide. Make sure you add /32 to the *Elastic IP*.
@@ -63,29 +64,45 @@ Open inbound ports on your security group. Use the table below as a guide. Make 
 7.  <a name="sshconnect"></a>In _EC2 Dashboard_ make your VM active by clicking it. Then click _Connect_ on top. The example in that window shows you how to ssh into your VM from a terminal.
 
 
-#### Adding private SSH key to your VM
+#### Adding a private SSH key to your VM
 
 Add your private ssh key under `~/.ssh/<your_key>.pem`, this is typically the same key that you use to SSH to your host VM, regardless it needs to be a key created on the AWS console so Amazon is aware of it. Then set privileges to _read-by-user-only_ by `chmod 400 ~/.ssh/<your_key>.pem` so your key is not publicly viewable.
 
 
+## Installing the Platform (CGP)
+
+These directions below assume you are using AWS.  We will include additional cloud instructions as `cgp-deployment` matures.
+
+
+### Collecting Information
+
+The installation script will prompt for several questions. It is useful to prepare for some of the answers beforehand to expedite the installation process. Here are a few pointers:
+
+* make sure you know what region you're running in (e.g. `us-west-2`)
+* decide whether you want to create an instance for development or production as it might impact the size and therefore the cost of the host virtual machine
+* find out whether your favorite editor is installed on host virtual machine
+* create a static IP address for your virtual machine (AWS calls this _Elastic IP_); find a short set of instructions below
+* you will be asked to provide an host domain that points to your EC2 instance; at the time of installation that domain (or _record set_) does not have to be configured in _Route 53_.
+
+### Running the Installer
+
+Once the above setup is done, clone this repository onto your server and run the bootstrap script. If needed checkout a particular branch or release tag you're interested after you execute the `git clone` command.
+
+    $ git clone https://github.com/DataBiosphere/cgp-deployment.git
+    $ cd cgp-deployment
+    $ sudo bash install_bootstrap
+
+The `install_bootstrap` script will ask you to configure each service interactively. Specifically, you need to decide on whether you require a production (`prod` mode) or a development (`dev` mode) environment.
+
 #### Installing in `prod` mode
-Once the above steps have been completed we are now ready to install the components of the CGP. As an example the following specification has worked well for a small-scale production environment :
-
-* Ubuntu Server 16.04
-* r4.xlarge
-* 250GB disk
-
+Once the above steps have been completed we are now ready to install the components of the CGP.
 In `prod` mode the installation will run the Docker containers for all of the components listed below from the respective images from *Quay.io*. The `nginx` docker will be built from the *nginx-image* directory.
 
 
 #### Installing in `dev` mode
-For development work the following specifications have worked well in the past:
-* Ubuntu Server 16.04
-* m5.large
-* 60 GB disk
-
-Setting up *Common* to run in `dev` mode will cause [Let's Encrypt](https://letsencrypt.org/) to issue fake SSL certificates. Setting up *Boardwalk* to run in `dev` mode will first build then run the Docker containers `boardwalk_nginx`, `boardwalk_dcc-dashboard`, `boardwalk_dcc-dashboard-service`, and `boardwalk_boardwalk` from the images (see [here](https://github.com/DataBiosphere/cgp-deployment/blob/feature/update-readme/boardwalk/README.md#development-mode) for more details). In addition, the `nginx` image is built from the *nginx-dev* directory. If your work requires real SSL certificates during development, it is recommended to set up *Common* in `prod` mode, and *Boardwalk* in `dev` mode.
-
+Setting up *Common* to run in `dev` mode will cause [Let's Encrypt](https://letsencrypt.org/) to issue fake SSL certificates, which won't exhaust your certificate's limit. Setting up *Boardwalk* to run in `dev` mode will first build then run the Docker containers `boardwalk_nginx`, `boardwalk_dcc-dashboard`, `boardwalk_dcc-dashboard-service`, and `boardwalk_boardwalk` from the images (see [here](https://github.com/DataBiosphere/cgp-deployment/blob/feature/update-readme/boardwalk/README.md#development-mode) for more details). In addition, the `nginx` image is built from the *nginx-dev* directory. If your work requires real SSL certificates during development, it is recommended to set up *Common* in `prod` mode, and *Boardwalk* in `dev` mode.
+  
+Once the installer completes, the system should be up and running. Congratulations! See `docker ps` to get an idea of what's running.
 
 #### TODO:
 
@@ -96,27 +113,7 @@ Setting up *Common* to run in `dev` mode will cause [Let's Encrypt](https://lets
 
 See the Boardwalk [README](boardwalk/README.md) for details.
 
-### Running the Installer
 
-Once the above setup is done, clone this repository onto your server and run the bootstrap script.
-
-    $ git clone https://github.com/DataBiosphere/cgp-deployment.git
-    $ cd cgp-deployment
-    $ sudo bash install_bootstrap
-
-Remember to checkout the particular branch or release tag that you're interested in if it's necessary.
-
-#### Installer Question Notes
-
-The `install_bootstrap` script will ask you to configure each service interactively.
-
-* Boardwalk
-  * Install in prod mode
-* Common
-  * Installing in `dev`mode will use letsencrypt's staging service, which won't exhaust your certificate's limit, but will install fake ssl certificates. `prod` mode will install official SSL certificates.
-  
-  
-Once the installer completes, the system should be up and running. Congratulations! See `docker ps` to get an idea of what's running.
 
 ## Post-Installation
 

--- a/README.md
+++ b/README.md
@@ -41,14 +41,14 @@ Use the AWS console or command line tool to create a host virtual machine. While
 * r4.xlarge
 * 250GB disk
 
-In `prod` mode the installation will run the Docker containers for all of the components listed below from the respective images from *Quay.io*.
+In `prod` mode the installation will run the Docker containers for all of the components listed below from the respective images from *Quay.io*. The `nginx` docker will be built from the *nginx-image* directory.
 
 For development work the following specifications have worked well in the past:
 * Ubuntu Server 16.04
 * m5.large
 * 60 GB disk
 
-Setting up *Common* to run in `dev` mode will cause [Let's Encrypt](https://letsencrypt.org/) to issue fake SSL certificates. Setting up *Boardwalk* to run in `dev` mode will first build then run the Docker containers `boardwalk_nginx`, `boardwalk_dcc-dashboard`, `boardwalk_dcc-dashboard-service`, and `boardwalk_boardwalk` from the images (see [here](https://github.com/DataBiosphere/cgp-deployment/blob/feature/update-readme/boardwalk/README.md#development-mode) for more details). If your work requires real SSL certificates during development, it is recommended to set up *Common* in `prod` mode, and *Boardwalk* in `dev` mode.
+Setting up *Common* to run in `dev` mode will cause [Let's Encrypt](https://letsencrypt.org/) to issue fake SSL certificates. Setting up *Boardwalk* to run in `dev` mode will first build then run the Docker containers `boardwalk_nginx`, `boardwalk_dcc-dashboard`, `boardwalk_dcc-dashboard-service`, and `boardwalk_boardwalk` from the images (see [here](https://github.com/DataBiosphere/cgp-deployment/blob/feature/update-readme/boardwalk/README.md#development-mode) for more details). In addition, the `nginx` image is built from the *nginx-dev* directory. If your work requires real SSL certificates during development, it is recommended to set up *Common* in `prod` mode, and *Boardwalk* in `dev` mode.
 
 
 #### <a name="makeip"></a>Create and assign an _Elastic IP_ for your VM 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The installation script will prompt for several questions. It is useful to prepa
 
 ### Launch an instance of a AWS EC2 virtual machine (VM)
 
-Use the AWS console or command line tool to create a host virtual machine. While you do this make a note of your security group name and ID and ensure you can [connect via ssh](#sshconnect). We will refer to this virtual machine as the VM throughout the rest of the documentation. Ultimately the performance and size of the VM depends on the traffic you expect. For example the following specification has worked well for a small-scale production environment:
+Use the AWS console or command line tool to create a host virtual machine. While you do this make a note of your security group name and ID and ensure you can [connect via ssh](#sshconnect). We will refer to this virtual machine as the VM throughout the rest of the documentation. Ultimately the performance and size of the VM depends on the traffic you expect. For example the following specification has worked well for a small-scale production environment (**Note:** We have had problems when uploading big files to Virginia (~25GB). If possible, set up your AWS anywhere else but Virginia.):
 
 * Ubuntu Server 16.04
 * r4.xlarge
@@ -45,12 +45,11 @@ In `prod` mode the installation will run the Docker containers for all of the co
 
 For development work the following specifications have worked well in the past:
 * Ubuntu Server 16.04
-* m5.xlarge
-* 80 GB disk
+* m5.large
+* 60 GB disk
 
 In `dev` mode Docker containers will be built from source and the VM will run them during testing. (see [here](https://github.com/DataBiosphere/cgp-deployment/blob/feature/update-readme/boardwalk/README.md#development-mode) for more details)
 
-**Note:** We have had problems when uploading big files to Virginia (~25GB). If possible, set up your AWS anywhere else but Virginia.
 
 #### Adding private SSH key to your VM
 

--- a/README.md
+++ b/README.md
@@ -25,18 +25,27 @@ These directions below assume you are using AWS.  We will include additional clo
 
 ### Collecting Information
 
-The installation script will prompt for several question. It is useful prepare for some of the answers beforehand to expedite the installation process. Here are a few pointers:
+The installation script will prompt for several questions. It is useful to prepare for some of the answers beforehand to expedite the installation process. Here are a few pointers:
 
 * make sure you know what region you're running in (e.g. `us-west-2`)
 * decide whether you want to create an instance for development or production as it might impact the size and therefore the cost of the host virtual machine
 * find out whether your favorite editor is installed on host virtual machine
-* be sure to know how to create a static IP address for your virtual machine (AWS calls this _Elastic IP_)
-* you will be asked to provide an host domain that points to your EC2 instance; at the time installation all you need is a name (i.e., the domain does not need to exist)
-* 
+* create a static IP address for your virtual machine (AWS calls this _Elastic IP_); find a short set of instructions below
+* you will be asked to provide an host domain that points to your EC2 instance; at the time of installation that domain (or _record set_) does not have to be configured in _Route 53_.
+
+#### Create an _Elastic IP_ for your VM
+1. Go to _AWS console_, _Compute_,  _EC2 Dashboard_. There click *running instances*. 
+2. Find your VM and make it active by clicking anywhere in that line.
+3. Under the drop-down *Actions*, go to *Networking*, *Manage IP Addreses*.
+4. Click on *Allocate an Elastic IP*. It will automatically create an IP address and show it on the screen.
+5. Write down that _Elastic IP_. At this point, whatever IP address is shown under IPv4 Public IP for your VM is not the current instance's IP address. Next you need to associate the _Elastic IP_ with your VM.
+6. Back in _EC2 Dashboard_ go to *Elastic IPs*. The IP address just created should be in that list. Check it and under *Actions*, *Associate*, choose resource type "Instance", and choose your EC2 (e.g., searching by its name).
+7. In _EC2 Dashboard_ make your VM active by clicking it. Then click _Connect_ on top. The example in that window shows you how to ssh into your VM from a terminal.
+
 
 ### Launch an instance of a AWS EC2 virtual machine (VM)
 
-Use the AWS console or command line tool to create a host virtual machine. We will refer to this machine as the VM throughout the rest of the documentation. Ultimately the performace and size of the VM depends on the traffic you expect. For example the following specification has worked well for a small-scale production environment:
+Use the AWS console or command line tool to create a host virtual machine. We will refer to this machine as the VM throughout the rest of the documentation. Ultimately the performance and size of the VM depends on the traffic you expect. For example the following specification has worked well for a small-scale production environment:
 
 * Ubuntu Server 16.04
 * r4.xlarge

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ For development work the following specifications have worked well in the past:
 * m5.large
 * 60 GB disk
 
-Setting up *Common* to run in `dev` mode will cause [Let's Encrypt](https://letsencrypt.org/) to issue fake SSL certificates. Setting up *Boardwalk* to run in `dev` mode will cause the Docker containers `boardwalk_nginx`, `boardwalk_dcc-dashboard`, `boardwalk_dcc-dashboard-service`, and `boardwalk_boardwalk` to be built from source (see [here](https://github.com/DataBiosphere/cgp-deployment/blob/feature/update-readme/boardwalk/README.md#development-mode) for more details). If your work requires real SSL certificates during development, it is recommended to set up *Common* in `prod` mode, and *Boardwalk* in `dev` mode.
+Setting up *Common* to run in `dev` mode will cause [Let's Encrypt](https://letsencrypt.org/) to issue fake SSL certificates. Setting up *Boardwalk* to run in `dev` mode will enable the option to instantiate the Docker containers `boardwalk_nginx`, `boardwalk_dcc-dashboard`, `boardwalk_dcc-dashboard-service`, and `boardwalk_boardwalk` from the images (see [here](https://github.com/DataBiosphere/cgp-deployment/blob/feature/update-readme/boardwalk/README.md#development-mode) for more details). If your work requires real SSL certificates during development, it is recommended to set up *Common* in `prod` mode, and *Boardwalk* in `dev` mode.
 
 
 #### <a name="makeip"></a>Create and assign an _Elastic IP_ for your VM 

--- a/README.md
+++ b/README.md
@@ -37,22 +37,20 @@ The installation script will prompt for several questions. It is useful to prepa
 
 Use the AWS console or command line tool to create a host virtual machine. While you do this make a note of your security group name and ID and ensure you can [connect via ssh](#sshconnect). We will refer to this virtual machine as the VM throughout the rest of the documentation. Ultimately the performance and size of the VM depends on the traffic you expect. (**Note:** We have had problems when uploading big files to Virginia (~25GB). If possible, set up your AWS anywhere else but Virginia.)
 
-#### Installing in `prod` mode
-As an example the following specification has worked well for a small-scale production environment :
+#### Configuring the ports in your VM
+Open inbound ports on your security group. Use the table below as a guide. Make sure you add /32 to the *Elastic IP*.
 
-* Ubuntu Server 16.04
-* r4.xlarge
-* 250GB disk
-
-In `prod` mode the installation will run the Docker containers for all of the components listed below from the respective images from *Quay.io*. The `nginx` docker will be built from the *nginx-image* directory.
-
-#### Installing in `dev` mode
-For development work the following specifications have worked well in the past:
-* Ubuntu Server 16.04
-* m5.large
-* 60 GB disk
-
-Setting up *Common* to run in `dev` mode will cause [Let's Encrypt](https://letsencrypt.org/) to issue fake SSL certificates. Setting up *Boardwalk* to run in `dev` mode will first build then run the Docker containers `boardwalk_nginx`, `boardwalk_dcc-dashboard`, `boardwalk_dcc-dashboard-service`, and `boardwalk_boardwalk` from the images (see [here](https://github.com/DataBiosphere/cgp-deployment/blob/feature/update-readme/boardwalk/README.md#development-mode) for more details). In addition, the `nginx` image is built from the *nginx-dev* directory. If your work requires real SSL certificates during development, it is recommended to set up *Common* in `prod` mode, and *Boardwalk* in `dev` mode.
+| Type | Port | Source | Description |
+| --- | --- | --- | --- |
+| HTTP | 80 | 0.0.0.0/0 | |
+| HTTP | 80 | ::/0 | |
+| HTTPS | 443 | 0.0.0.0/0 | |
+| HTTPS | 443 | ::/0 | |
+| All TCP | 0 - 65535 | _Your VM's Elastic IP_ | |
+| All TCP | 0 - 65535 | _Your Security Group ID_ | | 
+| Custom TCP Rule | 9000 | _Your VM's Elastic IP_ | webservice port |
+| Custom TCP Rule | 9200 | _Your VM's Elastic IP_ | Elasticsearch |
+| SSH | 22 | 0.0.0.0/0 | |
 
 
 #### <a name="makeip"></a>Create and assign an _Elastic IP_ for your VM 
@@ -69,20 +67,24 @@ Setting up *Common* to run in `dev` mode will cause [Let's Encrypt](https://lets
 
 Add your private ssh key under `~/.ssh/<your_key>.pem`, this is typically the same key that you use to SSH to your host VM, regardless it needs to be a key created on the AWS console so Amazon is aware of it. Then set privileges to _read-by-user-only_ by `chmod 400 ~/.ssh/<your_key>.pem` so your key is not publicly viewable.
 
-#### Configuring the ports in your VM
-Open inbound ports on your security group. Use the table below as a guide. Make sure you add /32 to the *Elastic IP*.
 
-| Type | Port | Source | Description |
-| --- | --- | --- | --- |
-| HTTP | 80 | 0.0.0.0/0 | |
-| HTTP | 80 | ::/0 | |
-| HTTPS | 443 | 0.0.0.0/0 | |
-| HTTPS | 443 | ::/0 | |
-| All TCP | 0 - 65535 | _Your VM's Elastic IP_ | |
-| All TCP | 0 - 65535 | _Your Security Group ID_ | | 
-| Custom TCP Rule | 9000 | _Your VM's Elastic IP_ | webservice port |
-| Custom TCP Rule | 9200 | _Your VM's Elastic IP_ | Elasticsearch |
-| SSH | 22 | 0.0.0.0/0 | |
+#### Installing in `prod` mode
+As an example the following specification has worked well for a small-scale production environment :
+
+* Ubuntu Server 16.04
+* r4.xlarge
+* 250GB disk
+
+In `prod` mode the installation will run the Docker containers for all of the components listed below from the respective images from *Quay.io*. The `nginx` docker will be built from the *nginx-image* directory.
+
+
+#### Installing in `dev` mode
+For development work the following specifications have worked well in the past:
+* Ubuntu Server 16.04
+* m5.large
+* 60 GB disk
+
+Setting up *Common* to run in `dev` mode will cause [Let's Encrypt](https://letsencrypt.org/) to issue fake SSL certificates. Setting up *Boardwalk* to run in `dev` mode will first build then run the Docker containers `boardwalk_nginx`, `boardwalk_dcc-dashboard`, `boardwalk_dcc-dashboard-service`, and `boardwalk_boardwalk` from the images (see [here](https://github.com/DataBiosphere/cgp-deployment/blob/feature/update-readme/boardwalk/README.md#development-mode) for more details). In addition, the `nginx` image is built from the *nginx-dev* directory. If your work requires real SSL certificates during development, it is recommended to set up *Common* in `prod` mode, and *Boardwalk* in `dev` mode.
 
 
 #### TODO:

--- a/README.md
+++ b/README.md
@@ -35,7 +35,10 @@ The installation script will prompt for several questions. It is useful to prepa
 
 ### Launch an instance of a AWS EC2 virtual machine (VM)
 
-Use the AWS console or command line tool to create a host virtual machine. While you do this make a note of your security group name and ID and ensure you can [connect via ssh](#sshconnect). We will refer to this virtual machine as the VM throughout the rest of the documentation. Ultimately the performance and size of the VM depends on the traffic you expect. For example the following specification has worked well for a small-scale production environment (**Note:** We have had problems when uploading big files to Virginia (~25GB). If possible, set up your AWS anywhere else but Virginia.):
+Use the AWS console or command line tool to create a host virtual machine. While you do this make a note of your security group name and ID and ensure you can [connect via ssh](#sshconnect). We will refer to this virtual machine as the VM throughout the rest of the documentation. Ultimately the performance and size of the VM depends on the traffic you expect. (**Note:** We have had problems when uploading big files to Virginia (~25GB). If possible, set up your AWS anywhere else but Virginia.)
+
+#### Installing in `prod` mode
+As an example the following specification has worked well for a small-scale production environment :
 
 * Ubuntu Server 16.04
 * r4.xlarge
@@ -43,6 +46,7 @@ Use the AWS console or command line tool to create a host virtual machine. While
 
 In `prod` mode the installation will run the Docker containers for all of the components listed below from the respective images from *Quay.io*. The `nginx` docker will be built from the *nginx-image* directory.
 
+#### Installing in `dev` mode
 For development work the following specifications have worked well in the past:
 * Ubuntu Server 16.04
 * m5.large


### PR DESCRIPTION
* provides more details as to how the inbound rules for the ports should look like
* added a few points to consider before user begins installation

TODO:
* `./integration.sh` fails and needs revision - in fact I recommend taking it out until we have it fixed
* not sure about the diagram at the top as it contains a lot of outdated information (e.g., Redwood, which is not included in this installation anymore)