### PR TITLE
two changes to enable Boardwalk to run in dev mode

### DIFF
--- a/install_bootstrap
+++ b/install_bootstrap
@@ -346,7 +346,7 @@ CONFIG
       # If in dev mode, check for dev repos and clone if not present
       if [ "${boardwalk_mode}" = "dev" ]; then
         check_for_repo https://github.com/DataBiosphere/cgp-dashboard.git dcc-dashboard
-        check_for_repo https://github.com/DataBiosphere/cgp-dashboard-service.git dcc-dashboard-service
+        check_for_repo https://github.com/DataBiosphere/azul.git azul
         check_for_repo https://github.com/DataBiosphere/cgp-boardwalk.git boardwalk
       fi
       # Bringing stuff down in case there are some cached containers

--- a/install_bootstrap
+++ b/install_bootstrap
@@ -40,9 +40,9 @@ MSG
 function check_for_repo {
     if [ ! -d "$2" ]; then
         git clone "$1" "$2"
-	cd "$2"
-	git checkout feature/commons
-	cd ..
+        cd "$2"
+        git checkout feature/commons
+        cd ..
     fi
 }
 
@@ -221,7 +221,7 @@ while [[ "${run_boardwalk^^}" != 'Y' &&  "${run_boardwalk^^}" != 'N' ]] ; do
       dcc_dashboard_port=8080
 
       if [ -f boardwalk_launcher_config/boardwalk.config ] ; then
-	  source <(jq -r "to_entries|map(\"\(.key)=\(.value|tostring)\")|.[]" boardwalk_launcher_config/boardwalk.config)
+          source <(jq -r "to_entries|map(\"\(.key)=\(.value|tostring)\")|.[]" boardwalk_launcher_config/boardwalk.config)
       fi
 
       echo "Do you want to run boardwalk in dev mode or prod? [dev/prod]"

--- a/install_bootstrap
+++ b/install_bootstrap
@@ -40,6 +40,9 @@ MSG
 function check_for_repo {
     if [ ! -d "$2" ]; then
         git clone "$1" "$2"
+	cd "$2"
+	git checkout feature/commons
+	cd ..
     fi
 }
 


### PR DESCRIPTION
To install the deployment for feature/commons in `dev` mode, these two changes became necessary after the Boardwalk dashboard service was moved to the `azul` repo:
* instead of cloning from `cgp-dashboard-service` 
* after each repo is cloned, the `check_for_repo` method will checkout the feature branch `feature/commons`