### PR TITLE
Corrected path to build dcc-dashboard-service service for dev-mode.

### DIFF
--- a/boardwalk/dev.yml
+++ b/boardwalk/dev.yml
@@ -21,7 +21,7 @@ services:
     #image: quay.io/ucsc_cgl/dashboard-service:1.0.0
     volumes:
       - ~/dcc-dashboard-service/logs:/app/log
-    build: dcc-dashboard-service
+    build: azul/webservice
     ports:
       - "80"
       - "443"


### PR DESCRIPTION
This corrects the build path for the `dcc-dashboard-service` in `dev.yml` for Boardwalk. It is not pointing to `azul/webservice`.