### PR TITLE
Adding env. vars. AWS_ACCESS_KEY and AWS_SECRET_ACCESS_KEY to installation files (#49).

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Open inbound ports on your security group. Use the table below as a guide. Make 
 #### Adding a private/public key pair to your local machine
 On your local machine add the key pair file under `~/.ssh/<your_key_pair>.pem`. This is typically the same key pair that you use to connect to your VM via SSH. This key pair needs to be created on the [AWS console](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html) so Amazon is aware of it. Set the privileges of that key pair file to _read-by-user-only_ by `chmod 400 ~/.ssh/<your_key>.pem` so it is not publicly viewable.
 
-#### Create an AWS S3 bucket for persistent storage of BDBag 
+####  <a name="makebucket"></a>Create an AWS S3 bucket for persistent storage of BDBag 
 The NIH Data Commons (DCPPC) uses BDBags to move metadata from one platform to another. In _Boardwalk_ a BDBag is created by clicking _Export to FireCloud_. Once clicked the selected metadata are packaged in a BDBag, and the bag is uploaded to an S3 bucket. Therefore, part of the installation process is creating an S3 bucket.
 Follow these steps to create it
 
@@ -93,6 +93,7 @@ The installation script (`install_bootstrap`) will prompt for several questions.
 * You will be asked to provide an host domain that points to your EC2 instance. You need to know the name of the domain but at the time of installation the domain (or _record set_) does not have to be configured in _Route 53_.
 * _Boardwalk_ has functionality to export metadata to Broad's FireCloud. In order to use it you need to provide your Google Cloud Platform credentials. Specifically you need the Google Client ID and the Google Client Secret (it's okay to leave the Google site verfication code empty). 
 * You need to input the [AWS IAM user](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html)'s _ access key ID_ and *secret_access_key*.
+* You need to have the name of the [S3 bucket you created earlier](#makebucket) handy as the install script will ask for it. The name you input has to be the same name you gave when you created the bucket.
 * All metadata reside in an Elasticsearch database. Make sure you have the domain name of that Elasticsearch instance handy.
 * Have the domain name of the _dos-dss server_ handy.
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,8 @@ The installation script (`install_bootstrap`) will prompt for several questions.
 * Find out whether your favorite editor is installed on the VM.
 * Create a static IP address for your VM (AWS calls this _Elastic IP_). You find a short set of instructions above.
 * You will be asked to provide an host domain that points to your EC2 instance. You need to know the name of the domain but at the time of installation the domain (or _record set_) does not have to be configured in _Route 53_.
-* _Boardwalk_ has functionality to export metadata to Broad's FireCloud. In order to use it you need to provide your Google Cloud Platform credentials. Specifically you need the Google Client ID and the Google Client Secret (it's okay to leave the Google site verfication code empty).
+* _Boardwalk_ has functionality to export metadata to Broad's FireCloud. In order to use it you need to provide your Google Cloud Platform credentials. Specifically you need the Google Client ID and the Google Client Secret (it's okay to leave the Google site verfication code empty). 
+* You need to input the [AWS IAM user](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html)'s _ access key ID_ and *secret_access_key*.
 * All metadata reside in an Elasticsearch database. Make sure you have the domain name of that Elasticsearch instance handy.
 * Have the domain name of the _dos-dss server_ handy.
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ The installation script (`install_bootstrap`) will prompt for several questions.
 * You will be asked to provide an host domain that points to your EC2 instance. You need to know the name of the domain but at the time of installation the domain (or _record set_) does not have to be configured in _Route 53_.
 * _Boardwalk_ has functionality to export metadata to Broad's FireCloud. In order to use it you need to provide your Google Cloud Platform credentials. Specifically you need the Google Client ID and the Google Client Secret (it's okay to leave the Google site verfication code empty). 
 * You need to input the [AWS IAM user](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html)'s _ access key ID_ and *secret_access_key*.
-* You need to have the name of the [S3 bucket you created earlier](#makebucket) handy as the install script will ask for it. The name you input has to be the same name you gave when you created the bucket.
+* You need to have the name of the [S3 bucket you created earlier](#makebucket) handy as the install script will ask for it. The name you input has to be the exact name you gave it when you created the bucket.
 * All metadata reside in an Elasticsearch database. Make sure you have the domain name of that Elasticsearch instance handy.
 * Have the domain name of the _dos-dss server_ handy.
 

--- a/boardwalk/conf/boardwalk.config.template
+++ b/boardwalk/conf/boardwalk.config.template
@@ -1,4 +1,6 @@
 azul_s3_bucket={{ AZUL_S3_BUCKET }}
+user_aws_key={{ AWS_ACCESS_KEY }}
+user_aws_secret_key={{ AWS_SECRET_ACCESS_KEY }}
 google_client_id={{ GOOGLE_CLIENT_ID }}
 google_client_secret={{ GOOGLE_CLIENT_SECRET }}
 google_site_verification_code= {{ GOOGLE_SITE_VERIFICATION_CODE }}

--- a/boardwalk/conf/boardwalk.config.template
+++ b/boardwalk/conf/boardwalk.config.template
@@ -1,5 +1,5 @@
 azul_s3_bucket={{ AZUL_S3_BUCKET }}
-user_aws_key={{ AWS_ACCESS_KEY }}
+user_aws_key_id={{ AWS_ACCESS_KEY_ID }}
 user_aws_secret_key={{ AWS_SECRET_ACCESS_KEY }}
 google_client_id={{ GOOGLE_CLIENT_ID }}
 google_client_secret={{ GOOGLE_CLIENT_SECRET }}

--- a/boardwalk/conf/boardwalk.config.template
+++ b/boardwalk/conf/boardwalk.config.template
@@ -1,3 +1,4 @@
+azul_s3_bucket={{ AZUL_S3_BUCKET }}
 google_client_id={{ GOOGLE_CLIENT_ID }}
 google_client_secret={{ GOOGLE_CLIENT_SECRET }}
 google_site_verification_code= {{ GOOGLE_SITE_VERIFICATION_CODE }}

--- a/boardwalk/dev.yml
+++ b/boardwalk/dev.yml
@@ -4,8 +4,8 @@ services:
   dcc-dashboard-service:
     environment:
       APACHE_PATH: "${apache_path}"
-      AWS_ACCESS_KEY_ID: "${user_aws_key_id}"
-      AWS_SECRET_ACCESS_KEY: "${user_aws_secret_key}"
+      AWS_ACCESS_KEY_ID: "${aws_access_key_id}"
+      AWS_SECRET_ACCESS_KEY: "${aws_secret_access_key}"
       AZUL_S3_BUCKET: "${azul_s3_bucket}"
       DATABASE_URL: "${database_url}"
       FLASK_APP: "/app/mapi.py"

--- a/boardwalk/dev.yml
+++ b/boardwalk/dev.yml
@@ -4,7 +4,7 @@ services:
   dcc-dashboard-service:
     environment:
       APACHE_PATH: "${apache_path}"
-      AWS_ACCESS_KEY_ID: "${user_aws_key}"
+      AWS_ACCESS_KEY_ID: "${user_aws_key_id}"
       AWS_SECRET_ACCESS_KEY: "${user_aws_secret_key}"
       AZUL_S3_BUCKET: "${azul_s3_bucket}"
       DATABASE_URL: "${database_url}"

--- a/boardwalk/dev.yml
+++ b/boardwalk/dev.yml
@@ -4,6 +4,7 @@ services:
   dcc-dashboard-service:
     environment:
       APACHE_PATH: "${apache_path}"
+      AZUL_S3_BUCKET: "${azul_s3_bucket}"
       DATABASE_URL: "${database_url}"
       FLASK_APP: "/app/mapi.py"
       DCC_DASHBOARD_HOST: "${dcc_dashboard_host}"

--- a/boardwalk/dev.yml
+++ b/boardwalk/dev.yml
@@ -4,6 +4,8 @@ services:
   dcc-dashboard-service:
     environment:
       APACHE_PATH: "${apache_path}"
+      AWS_ACCESS_KEY_ID: "${user_aws_key}"
+      AWS_SECRET_ACCESS_KEY: "${user_aws_secret_key}"
       AZUL_S3_BUCKET: "${azul_s3_bucket}"
       DATABASE_URL: "${database_url}"
       FLASK_APP: "/app/mapi.py"

--- a/boardwalk/prod.yml
+++ b/boardwalk/prod.yml
@@ -4,8 +4,8 @@ services:
   dcc-dashboard-service:
     environment:
       APACHE_PATH: "${apache_path}"
-      AWS_ACCESS_KEY_ID: "${user_aws_key_id}"
-      AWS_SECRET_ACCESS_KEY: "${user_aws_secret_key}"
+      AWS_ACCESS_KEY_ID: "${aws_access_key_id}"
+      AWS_SECRET_ACCESS_KEY: "${aws_secret_access_key}"
       AZUL_S3_BUCKET: "${azul_s3_bucket}"
       DATABASE_URL: "${database_url}"
       FLASK_APP: "/app/mapi.py"

--- a/boardwalk/prod.yml
+++ b/boardwalk/prod.yml
@@ -5,6 +5,8 @@ services:
     environment:
       APACHE_PATH: "${apache_path}"
       AZUL_S3_BUCKET: "${azul_s3_bucket}"
+      AWS_ACCESS_KEY_ID: "${user_aws_key}"
+      AWS_SECRET_ACCESS_KEY: "${user_aws_secret_key}"
       DATABASE_URL: "${database_url}"
       FLASK_APP: "/app/mapi.py"
       DCC_DASHBOARD_HOST: "${dcc_dashboard_host}"

--- a/boardwalk/prod.yml
+++ b/boardwalk/prod.yml
@@ -4,7 +4,7 @@ services:
   dcc-dashboard-service:
     environment:
       APACHE_PATH: "${apache_path}"
-      AWS_ACCESS_KEY_ID: "${user_aws_key}"
+      AWS_ACCESS_KEY_ID: "${user_aws_key_id}"
       AWS_SECRET_ACCESS_KEY: "${user_aws_secret_key}"
       AZUL_S3_BUCKET: "${azul_s3_bucket}"
       DATABASE_URL: "${database_url}"

--- a/boardwalk/prod.yml
+++ b/boardwalk/prod.yml
@@ -4,9 +4,9 @@ services:
   dcc-dashboard-service:
     environment:
       APACHE_PATH: "${apache_path}"
-      AZUL_S3_BUCKET: "${azul_s3_bucket}"
       AWS_ACCESS_KEY_ID: "${user_aws_key}"
       AWS_SECRET_ACCESS_KEY: "${user_aws_secret_key}"
+      AZUL_S3_BUCKET: "${azul_s3_bucket}"
       DATABASE_URL: "${database_url}"
       FLASK_APP: "/app/mapi.py"
       DCC_DASHBOARD_HOST: "${dcc_dashboard_host}"

--- a/boardwalk/prod.yml
+++ b/boardwalk/prod.yml
@@ -4,6 +4,7 @@ services:
   dcc-dashboard-service:
     environment:
       APACHE_PATH: "${apache_path}"
+      AZUL_S3_BUCKET: "${azul_s3_bucket}"
       DATABASE_URL: "${database_url}"
       FLASK_APP: "/app/mapi.py"
       DCC_DASHBOARD_HOST: "${dcc_dashboard_host}"

--- a/install_bootstrap
+++ b/install_bootstrap
@@ -277,7 +277,7 @@ while [[ "${run_boardwalk^^}" != 'Y' &&  "${run_boardwalk^^}" != 'N' ]] ; do
       ask_question "What is the domain of the bagit-firecloud-lambda?" "$FC_LAMBDA_DOMAIN" "FireCloud Bagit Lambda Domain" $fc_lambda_domain
 
       azul_s3_bucket='azul_s3_bucket'
-      ask_question "What is the name of the AWS S3 bucket to store BDBags for 1 day?" "$AZUL_S3_BUCKET" "Azul S3 Bucket" $azul_s3_bucket
+      ask_question "What is the name of the AWS S3 bucket to store BDBags?" "$AZUL_S3_BUCKET" "Azul S3 Bucket" $azul_s3_bucket
 
 
 #      dcc_dashboard_port='dcc_dashboard_port'

--- a/install_bootstrap
+++ b/install_bootstrap
@@ -276,7 +276,7 @@ while [[ "${run_boardwalk^^}" != 'Y' &&  "${run_boardwalk^^}" != 'N' ]] ; do
       ask_question "What is the domain of the bagit-firecloud-lambda?" "$FC_LAMBDA_DOMAIN" "FireCloud Bagit Lambda Domain" $fc_lambda_domain
 
       azul_s3_bucket='azul_s3_bucket'
-      ask_question "What is the domain of the AWS S3 bucket where BDBag for Export-to-FireCloud are stored?" $azul_s3_bucket
+      ask_question "What is the name of the AWS S3 bucket where BDBag for Export-to-FireCloud are stored?" $azul_s3_bucket
 
 
 #      dcc_dashboard_port='dcc_dashboard_port'
@@ -318,6 +318,7 @@ while [[ "${run_boardwalk^^}" != 'Y' &&  "${run_boardwalk^^}" != 'N' ]] ; do
 
       cat > boardwalk_launcher_config/boardwalk.config <<CONFIG
 {
+"AZUL_S3_BUCKET": "${azul_s3_bucket}",
 "GOOGLE_CLIENT_ID":"${google_client_id}",
 "GOOGLE_CLIENT_SECRET":"${google_client_secret}",
 "GOOGLE_SITE_VERIFICATION_CODE":"${google_site_verification_code}",

--- a/install_bootstrap
+++ b/install_bootstrap
@@ -46,16 +46,6 @@ function check_for_repo {
     fi
 }
 
-# To test run the script. Delete this once merged with feature/commons.
-function check_for_repo2 {
-    if [ ! -d "$2" ]; then
-        git clone "$1" "$2"
-        cd "$2"
-	git checkout feature/tlp-424
-        cd ..
-    fi
-}
-
 
 function generate_password {
     tr -cd '[:alnum:]' < /dev/urandom | fold -w30 | head -n1

--- a/install_bootstrap
+++ b/install_bootstrap
@@ -41,9 +41,7 @@ function check_for_repo {
     if [ ! -d "$2" ]; then
         git clone "$1" "$2"
         cd "$2"
-        #git checkout feature/commons
-	# To test run the script:
-	git checkout feature/tlp-424
+        git checkout feature/commons
         cd ..
     fi
 }

--- a/install_bootstrap
+++ b/install_bootstrap
@@ -362,8 +362,7 @@ CONFIG
       # If in dev mode, check for dev repos and clone if not present
       if [ "${boardwalk_mode}" = "dev" ]; then
         check_for_repo https://github.com/DataBiosphere/cgp-dashboard.git dcc-dashboard
-        #check_for_repo https://github.com/DataBiosphere/azul.git azul
-	check_for_repo2 https://github.com/DataBiosphere/azul.git azul
+        check_for_repo https://github.com/DataBiosphere/azul.git azul
         check_for_repo https://github.com/DataBiosphere/cgp-boardwalk.git boardwalk
       fi
       # Bringing stuff down in case there are some cached containers

--- a/install_bootstrap
+++ b/install_bootstrap
@@ -337,8 +337,8 @@ while [[ "${run_boardwalk^^}" != 'Y' &&  "${run_boardwalk^^}" != 'N' ]] ; do
       cat > boardwalk_launcher_config/boardwalk.config <<CONFIG
 {
 "AZUL_S3_BUCKET":"${azul_s3_bucket}",
-"AWS_ACCESS_KEY_ID":${user_aws_key},
-"AWS_SECRET_ACCESS_KEY":${user_aws_secret_key},
+"AWS_ACCESS_KEY_ID":"${user_aws_key}",
+"AWS_SECRET_ACCESS_KEY":"${user_aws_secret_key}",
 "DATABASE_URL":"${database_url}",
 "DCC_DASHBOARD_HOST":"${dcc_dashboard_host}",
 "DCC_DASHBOARD_PROTOCOL":"${dcc_dashboard_protocol}",

--- a/install_bootstrap
+++ b/install_bootstrap
@@ -258,8 +258,8 @@ while [[ "${run_boardwalk^^}" != 'Y' &&  "${run_boardwalk^^}" != 'N' ]] ; do
       # AWS questions            #
       ############################
 
-      user_aws_key='user_aws_key'
-      ask_question "What is your AWS Key?" "$AWS_ACCESS_KEY_ID" "AWS Key name" $user_aws_key
+      user_aws_key_id='user_aws_key_id'
+      ask_question "What is your AWS Key?" "$AWS_ACCESS_KEY_ID" "AWS Key name" $user_aws_key_id
 
       user_aws_secret_key='user_aws_secret_key'
       ask_question "What is your AWS Secret Key?" "$AWS_SECRET_ACCESS_KEY" "AWS Secret Key name" $user_aws_secret_key 
@@ -337,7 +337,7 @@ while [[ "${run_boardwalk^^}" != 'Y' &&  "${run_boardwalk^^}" != 'N' ]] ; do
       cat > boardwalk_launcher_config/boardwalk.config <<CONFIG
 {
 "AZUL_S3_BUCKET":"${azul_s3_bucket}",
-"AWS_ACCESS_KEY_ID":"${user_aws_key}",
+"AWS_ACCESS_KEY_ID":"${user_aws_key_id}",
 "AWS_SECRET_ACCESS_KEY":"${user_aws_secret_key}",
 "DATABASE_URL":"${database_url}",
 "DCC_DASHBOARD_HOST":"${dcc_dashboard_host}",

--- a/install_bootstrap
+++ b/install_bootstrap
@@ -248,7 +248,7 @@ while [[ "${run_boardwalk^^}" != 'Y' &&  "${run_boardwalk^^}" != 'N' ]] ; do
 #            read -ep $'What is the email address for notification?  Previous value: \n' -i "$EMAIL_ADDRESS" email_address
 #         else
 #            read -ep $'What is the email address for notification? \n' email_address
-      #      fi
+#      fi
 
       
       dcc_dashboard_host='dcc_dashboard_host'

--- a/install_bootstrap
+++ b/install_bootstrap
@@ -41,10 +41,23 @@ function check_for_repo {
     if [ ! -d "$2" ]; then
         git clone "$1" "$2"
         cd "$2"
-        git checkout feature/commons
+        #git checkout feature/commons
+	# To test run the script:
+	git checkout feature/tlp-424
         cd ..
     fi
 }
+
+# To test run the script. Delete this once merged with feature/commons.
+function check_for_repo2 {
+    if [ ! -d "$2" ]; then
+        git clone "$1" "$2"
+        cd "$2"
+	git checkout feature/tlp-424
+        cd ..
+    fi
+}
+
 
 function generate_password {
     tr -cd '[:alnum:]' < /dev/urandom | fold -w30 | head -n1
@@ -351,7 +364,8 @@ CONFIG
       # If in dev mode, check for dev repos and clone if not present
       if [ "${boardwalk_mode}" = "dev" ]; then
         check_for_repo https://github.com/DataBiosphere/cgp-dashboard.git dcc-dashboard
-        check_for_repo https://github.com/DataBiosphere/azul.git azul
+        #check_for_repo https://github.com/DataBiosphere/azul.git azul
+	check_for_repo2 https://github.com/DataBiosphere/azul.git azul
         check_for_repo https://github.com/DataBiosphere/cgp-boardwalk.git boardwalk
       fi
       # Bringing stuff down in case there are some cached containers

--- a/install_bootstrap
+++ b/install_bootstrap
@@ -275,6 +275,10 @@ while [[ "${run_boardwalk^^}" != 'Y' &&  "${run_boardwalk^^}" != 'N' ]] ; do
       fc_lambda_domain='fc_lambda_domain'
       ask_question "What is the domain of the bagit-firecloud-lambda?" "$FC_LAMBDA_DOMAIN" "FireCloud Bagit Lambda Domain" $fc_lambda_domain
 
+      azul_s3_bucket='azul_s3_bucket'
+      ask_question "What is the domain of the AWS S3 bucket where BDBag for Export-to-FireCloud are stored?" $azul_s3_bucket
+
+
 #      dcc_dashboard_port='dcc_dashboard_port'
 #      ask_question "What is your DCC Dashboard Port?" "$DCC_DASHBOARD_PORT" "DCC Dashboard Port" $dcc_dashboard_port
 

--- a/install_bootstrap
+++ b/install_bootstrap
@@ -257,11 +257,11 @@ while [[ "${run_boardwalk^^}" != 'Y' &&  "${run_boardwalk^^}" != 'N' ]] ; do
       # AWS questions            #
       ############################
 
-      user_aws_key_id='user_aws_key_id'
-      ask_question "What is your AWS Key?" "$AWS_ACCESS_KEY_ID" "AWS Key name" $user_aws_key_id
+      aws_access_key_id='aws_access_key_id'
+      ask_question "What is your AWS Key?" "$AWS_ACCESS_KEY_ID" "AWS Key name" $aws_access_key_id
 
-      user_aws_secret_key='user_aws_secret_key'
-      ask_question "What is your AWS Secret Key?" "$AWS_SECRET_ACCESS_KEY" "AWS Secret Key name" $user_aws_secret_key 
+      aws_secret_access_key='aws_secret_access_key'
+      ask_question "What is your AWS Secret Key?" "$AWS_SECRET_ACCESS_KEY" "AWS Secret Key name" $aws_secret_access_key 
 
 
       #############################
@@ -336,8 +336,8 @@ while [[ "${run_boardwalk^^}" != 'Y' &&  "${run_boardwalk^^}" != 'N' ]] ; do
       cat > boardwalk_launcher_config/boardwalk.config <<CONFIG
 {
 "AZUL_S3_BUCKET":"${azul_s3_bucket}",
-"AWS_ACCESS_KEY_ID":"${user_aws_key_id}",
-"AWS_SECRET_ACCESS_KEY":"${user_aws_secret_key}",
+"AWS_ACCESS_KEY_ID":"${aws_access_key_id}",
+"AWS_SECRET_ACCESS_KEY":"${aws_secret_access_key}",
 "DATABASE_URL":"${database_url}",
 "DCC_DASHBOARD_HOST":"${dcc_dashboard_host}",
 "DCC_DASHBOARD_PROTOCOL":"${dcc_dashboard_protocol}",

--- a/install_bootstrap
+++ b/install_bootstrap
@@ -208,8 +208,6 @@ else
     echo "the core won't be publicly accessible until the gateway is started"
 fi
 
-
-
 # RUN THE BOARDWALK INSTALLER
 run_boardwalk=''
 while [[ "${run_boardwalk^^}" != 'Y' &&  "${run_boardwalk^^}" != 'N' ]] ; do
@@ -250,17 +248,36 @@ while [[ "${run_boardwalk^^}" != 'Y' &&  "${run_boardwalk^^}" != 'N' ]] ; do
 #            read -ep $'What is the email address for notification?  Previous value: \n' -i "$EMAIL_ADDRESS" email_address
 #         else
 #            read -ep $'What is the email address for notification? \n' email_address
-#      fi
+      #      fi
 
+      
       dcc_dashboard_host='dcc_dashboard_host'
       ask_question "What is the hostname of dcc-dashboard? (This is likely the domain name resolving to your virtual machine.)" "$DCC_DASHBOARD_HOST" "DCC Dashboard Host" $dcc_dashboard_host
-        
+      
+      ############################
+      # AWS questions            #
+      ############################
+
+      user_aws_key='user_aws_key'
+      ask_question "What is your AWS Key?" "$AWS_ACCESS_KEY_ID" "AWS Key name" $user_aws_key
+
+      user_aws_secret_key='user_aws_secret_key'
+      ask_question "What is your AWS Secret Key?" "$AWS_SECRET_ACCESS_KEY" "AWS Secret Key name" $user_aws_secret_key 
+
+
+      #############################
+      # Elasticsearch questions   #
+      #############################
       es_port='443'
       es_protocol='https'
 
       es_domain='es_domain'
       ask_question "What is the domain of the elasticsearch instance?" "$ES_DOMAIN" "Elasticsearch domain" $es_domain
 
+
+      #############################
+      # Google Cloud Services     #
+      #############################
       google_client_id='google_client_id'
       ask_question "What is your Google Client ID?" "$GOOGLE_CLIENT_ID" "Google Client ID" $google_client_id
 
@@ -289,12 +306,12 @@ while [[ "${run_boardwalk^^}" != 'Y' &&  "${run_boardwalk^^}" != 'N' ]] ; do
 #      dcc_dashboard_service='dcc_dashboard_service'
 #      ask_question "Where is your DCC Dashboard Service domain?" "$DCC_DASHBOARD_SERVICE" "DCC Dashboard Service" $dcc_dashboard_service
 
-       dcc_dashboard_service=$dcc_dashboard_host
+      dcc_dashboard_service=$dcc_dashboard_host
 
 #      dcc_invoicing_service='dcc_invoicing_service'
 #      ask_question "What is your DCC Invocing Service domain?" "$DCC_INVOICING_SERVICE" "DCC Invoicing Service" $dcc_invoicing_service
 
-       dcc_invoicing_service=$dcc_dashboard_host
+      dcc_invoicing_service=$dcc_dashboard_host
 
       dos_dss_service='dos_dss_service'
       ask_question "What is the domain of the dos-dss server?" "$DOS_DSS_SERVICE" "DOS DSS Service" $dos_dss_service
@@ -319,30 +336,32 @@ while [[ "${run_boardwalk^^}" != 'Y' &&  "${run_boardwalk^^}" != 'N' ]] ; do
 
       cat > boardwalk_launcher_config/boardwalk.config <<CONFIG
 {
-"AZUL_S3_BUCKET": "${azul_s3_bucket}",
-"GOOGLE_CLIENT_ID":"${google_client_id}",
-"GOOGLE_CLIENT_SECRET":"${google_client_secret}",
-"GOOGLE_SITE_VERIFICATION_CODE":"${google_site_verification_code}",
+"AZUL_S3_BUCKET":"${azul_s3_bucket}",
+"AWS_ACCESS_KEY_ID":${user_aws_key},
+"AWS_SECRET_ACCESS_KEY":${user_aws_secret_key},
+"DATABASE_URL":"${database_url}",
 "DCC_DASHBOARD_HOST":"${dcc_dashboard_host}",
 "DCC_DASHBOARD_PROTOCOL":"${dcc_dashboard_protocol}",
 "DCC_DASHBOARD_SERVICE":"${dcc_dashboard_service}",
 "DCC_INVOICING_SERVICE":"${dcc_invoicing_service}",
-"DATABASE_URL":"${database_url}",
-"USER_GROUP":"${user_group}",
+"DCC_CORE_CLIENT_VERSION":"${core_client_version}",
+"DOS_DSS_SERVICE":"${dos_dss_service}",
 "ES_DOMAIN":"${es_domain}",
 "ES_PORT":"${es_port}",
 "ES_PROTOCOL":"${es_protocol}",
-"LOGIN_POSTGRES_USER":"${login_user}",
-"LOGIN_POSTGRES_DB":"${login_db}",
-"LOGIN_POSTGRES_PASSWORD":"${login_password}",
-"SECRET_KEY":"${secret_key}",
-"LOG_IN_TOKEN":"${login_token}",
-"SERVER_NAME":"${dcc_dashboard_host}",
-"DCC_CORE_CLIENT_VERSION":"${core_client_version}",
 "FC_LAMBDA_PROTOCOL":"${fc_lambda_protocol}",
 "FC_LAMBDA_DOMAIN":"${fc_lambda_domain}",
 "FC_LAMBDA_PORT":"${fc_lambda_port}",
-"DOS_DSS_SERVICE":"${dos_dss_service}"
+"GOOGLE_CLIENT_ID":"${google_client_id}",
+"GOOGLE_CLIENT_SECRET":"${google_client_secret}",
+"GOOGLE_SITE_VERIFICATION_CODE":"${google_site_verification_code}",
+"LOGIN_POSTGRES_USER":"${login_user}",
+"LOGIN_POSTGRES_DB":"${login_db}",
+"LOGIN_POSTGRES_PASSWORD":"${login_password}",
+"LOG_IN_TOKEN":"${login_token}",
+"SECRET_KEY":"${secret_key}",
+"SERVER_NAME":"${dcc_dashboard_host}",
+"USER_GROUP":"${user_group}"
 }
 CONFIG
       # template out stuff

--- a/install_bootstrap
+++ b/install_bootstrap
@@ -289,7 +289,7 @@ while [[ "${run_boardwalk^^}" != 'Y' &&  "${run_boardwalk^^}" != 'N' ]] ; do
       ask_question "What is the domain of the bagit-firecloud-lambda?" "$FC_LAMBDA_DOMAIN" "FireCloud Bagit Lambda Domain" $fc_lambda_domain
 
       azul_s3_bucket='azul_s3_bucket'
-      ask_question "What is the name of the AWS S3 bucket where BDBag for Export-to-FireCloud are stored?" $azul_s3_bucket
+      ask_question "What is the name of the AWS S3 bucket where BDBag for Export-to-FireCloud are stored?" "$AZUL_S3_BUCKET" "Azul S3 Bucket" $azul_s3_bucket
 
 
 #      dcc_dashboard_port='dcc_dashboard_port'

--- a/install_bootstrap
+++ b/install_bootstrap
@@ -46,7 +46,6 @@ function check_for_repo {
     fi
 }
 
-
 function generate_password {
     tr -cd '[:alnum:]' < /dev/urandom | fold -w30 | head -n1
 }

--- a/install_bootstrap
+++ b/install_bootstrap
@@ -277,7 +277,7 @@ while [[ "${run_boardwalk^^}" != 'Y' &&  "${run_boardwalk^^}" != 'N' ]] ; do
       ask_question "What is the domain of the bagit-firecloud-lambda?" "$FC_LAMBDA_DOMAIN" "FireCloud Bagit Lambda Domain" $fc_lambda_domain
 
       azul_s3_bucket='azul_s3_bucket'
-      ask_question "What is the name of the AWS S3 bucket where BDBag for Export-to-FireCloud are stored?" "$AZUL_S3_BUCKET" "Azul S3 Bucket" $azul_s3_bucket
+      ask_question "What is the name of the AWS S3 bucket to store BDBags for 1 day?" "$AZUL_S3_BUCKET" "Azul S3 Bucket" $azul_s3_bucket
 
 
 #      dcc_dashboard_port='dcc_dashboard_port'


### PR DESCRIPTION
I added the two environment variables AWS_ACCESS_KEY and AWS_SECRET_ACCESS_KEY
to the following installation files (address #49 ):

* install_bootstrap
* boardwalk/dev.yml
* boardwalk/prod.yml
* boardwalk/conf/boardwalk.config.template

so they can be read into container dcc_dashboard-service_1. This is needed for upload to an S3 bucket. Installation succeeded and correctly added the environment variables to `.env`.