### PR TITLE
Change AWS variable names in mustache template for Boardwalk (fixes #49)

### DIFF
--- a/boardwalk/conf/boardwalk.config.template
+++ b/boardwalk/conf/boardwalk.config.template
@@ -1,6 +1,6 @@
 azul_s3_bucket={{ AZUL_S3_BUCKET }}
-user_aws_key_id={{ AWS_ACCESS_KEY_ID }}
-user_aws_secret_key={{ AWS_SECRET_ACCESS_KEY }}
+aws_access_key_id={{ AWS_ACCESS_KEY_ID }}
+aws_secret_access_key={{ AWS_SECRET_ACCESS_KEY }}
 google_client_id={{ GOOGLE_CLIENT_ID }}
 google_client_secret={{ GOOGLE_CLIENT_SECRET }}
 google_site_verification_code= {{ GOOGLE_SITE_VERIFICATION_CODE }}

--- a/install_bootstrap
+++ b/install_bootstrap
@@ -46,16 +46,6 @@ function check_for_repo {
     fi
 }
 
-function check_for_repo2 {
-    if [ ! -d "$2" ]; then
-        git clone "$1" "$2"
-        cd "$2"
-        git checkout feature/persistent-bdbag
-        cd ..
-    fi
-}
-
-
 function generate_password {
     tr -cd '[:alnum:]' < /dev/urandom | fold -w30 | head -n1
 }
@@ -380,7 +370,7 @@ CONFIG
       # If in dev mode, check for dev repos and clone if not present
       if [ "${boardwalk_mode}" = "dev" ]; then
         check_for_repo https://github.com/DataBiosphere/cgp-dashboard.git dcc-dashboard
-        check_for_repo2 https://github.com/DataBiosphere/azul.git azul
+        check_for_repo https://github.com/DataBiosphere/azul.git azul
         check_for_repo https://github.com/DataBiosphere/cgp-boardwalk.git boardwalk
       fi
       # Bringing stuff down in case there are some cached containers

--- a/install_bootstrap
+++ b/install_bootstrap
@@ -41,7 +41,8 @@ function check_for_repo {
     if [ ! -d "$2" ]; then
         git clone "$1" "$2"
         cd "$2"
-        git checkout feature/commons
+        #git checkout feature/commons
+        git checkout feature/persistent-bdbag
         cd ..
     fi
 }

--- a/install_bootstrap
+++ b/install_bootstrap
@@ -41,11 +41,20 @@ function check_for_repo {
     if [ ! -d "$2" ]; then
         git clone "$1" "$2"
         cd "$2"
-        #git checkout feature/commons
+        git checkout feature/commons
+        cd ..
+    fi
+}
+
+function check_for_repo2 {
+    if [ ! -d "$2" ]; then
+        git clone "$1" "$2"
+        cd "$2"
         git checkout feature/persistent-bdbag
         cd ..
     fi
 }
+
 
 function generate_password {
     tr -cd '[:alnum:]' < /dev/urandom | fold -w30 | head -n1
@@ -371,7 +380,7 @@ CONFIG
       # If in dev mode, check for dev repos and clone if not present
       if [ "${boardwalk_mode}" = "dev" ]; then
         check_for_repo https://github.com/DataBiosphere/cgp-dashboard.git dcc-dashboard
-        check_for_repo https://github.com/DataBiosphere/azul.git azul
+        check_for_repo2 https://github.com/DataBiosphere/azul.git azul
         check_for_repo https://github.com/DataBiosphere/cgp-boardwalk.git boardwalk
       fi
       # Bringing stuff down in case there are some cached containers


### PR DESCRIPTION
In #49 I did not change the variable names (not the names of the environment variables) 

* from `user_aws_key_id` to `aws_access_key_id`
* from `user_aws_secret_key` to `aws_secret_access_key`

This has been done here in file `boardwalk.config.template` in order to have consistent naming of environment variables across several files in this repo. 

I ran `install_bootstrap` with those changes. It installed normally, I could log-in to the Boardwalk instance and was able upload to S3 (which uses those credentials) worked.

NOTE: I changed `install_bootstrap` that enabled the S3 upload to test the changes in this `boardwalk.config.template`, but then reversed all changes made to `install_bootstrap` again.
