### PR TITLE
Add AWS vars to dashboard and fix encryption key

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,9 +206,10 @@ what to put for each step.
    name of the domain, but at the time of installation the domain (or
    _record set_) does not _actually_ have to be configured in _Route 53_
 
-1. Next you are prompted for AWS credentials. These can be made
-   specifically for the instance, or for a dev instance you could use
-   your own.
+1. Next you are prompted for the default AWS region to be used and for
+   AWS credentials. The region is the one you whitelist, buckets, etc.
+   are in. The credentials can be made specifically for the instance, or
+   for a dev instance you could use your own.
 
 1. The elasticsearch instance domain can be one that is prexisting if
    used only for development.

--- a/README.md
+++ b/README.md
@@ -206,10 +206,10 @@ what to put for each step.
    name of the domain, but at the time of installation the domain (or
    _record set_) does not _actually_ have to be configured in _Route 53_
 
-1. Next you are prompted for the default AWS region to be used and for
-   AWS credentials. The region is the one you whitelist, buckets, etc.
-   are in. The credentials can be made specifically for the instance, or
-   for a dev instance you could use your own.
+1. Next you are prompted for the AWS region to be used and for AWS
+   credentials. The region is the one you whitelist, buckets, etc.  are
+   in. The credentials can be made specifically for the instance, or for
+   a dev instance you could use your own.
 
 1. The elasticsearch instance domain can be one that is prexisting if
    used only for development.

--- a/boardwalk/conf/boardwalk.config.template
+++ b/boardwalk/conf/boardwalk.config.template
@@ -1,4 +1,5 @@
 azul_s3_bucket={{ AZUL_S3_BUCKET }}
+aws_default_region={{ AWS_DEFAULT_REGION }}
 aws_access_key_id={{ AWS_ACCESS_KEY_ID }}
 aws_secret_access_key={{ AWS_SECRET_ACCESS_KEY }}
 project_name={{ PROJECT_NAME }}

--- a/boardwalk/dev.yml
+++ b/boardwalk/dev.yml
@@ -52,6 +52,8 @@ services:
       GOOGLE_CLIENT_ID: "${google_client_id}"
       GOOGLE_CLIENT_SECRET: "${google_client_secret}"
       GOOGLE_SITE_VERIFICATION_CODE: "${google_site_verification_code}"
+      AWS_ACCESS_KEY_ID: "${aws_access_key_id}"
+      AWS_SECRET_ACCESS_KEY: "${aws_secret_access_key}"
       DCC_DASHBOARD_HOST: "${dcc_dashboard_host}"
       DCC_DASHBOARD_PROTOCOL: "${dcc_dashboard_protocol}"
       DCC_DASHBOARD_SERVICE: "${dcc_dashboard_service}"

--- a/boardwalk/dev.yml
+++ b/boardwalk/dev.yml
@@ -52,6 +52,7 @@ services:
       GOOGLE_CLIENT_ID: "${google_client_id}"
       GOOGLE_CLIENT_SECRET: "${google_client_secret}"
       GOOGLE_SITE_VERIFICATION_CODE: "${google_site_verification_code}"
+      AWS_DEFAULT_REGION: "${aws_default_region}"
       AWS_ACCESS_KEY_ID: "${aws_access_key_id}"
       AWS_SECRET_ACCESS_KEY: "${aws_secret_access_key}"
       DCC_DASHBOARD_HOST: "${dcc_dashboard_host}"

--- a/boardwalk/prod.yml
+++ b/boardwalk/prod.yml
@@ -52,6 +52,8 @@ services:
       GOOGLE_CLIENT_ID: "${google_client_id}"
       GOOGLE_CLIENT_SECRET: "${google_client_secret}"
       GOOGLE_SITE_VERIFICATION_CODE: "${google_site_verification_code}"
+      AWS_ACCESS_KEY_ID: "${aws_access_key_id}"
+      AWS_SECRET_ACCESS_KEY: "${aws_secret_access_key}"
       DCC_DASHBOARD_HOST: "${dcc_dashboard_host}"
       DCC_DASHBOARD_PROTOCOL: "${dcc_dashboard_protocol}"
       DCC_DASHBOARD_SERVICE: "${dcc_dashboard_service}"

--- a/boardwalk/prod.yml
+++ b/boardwalk/prod.yml
@@ -52,6 +52,7 @@ services:
       GOOGLE_CLIENT_ID: "${google_client_id}"
       GOOGLE_CLIENT_SECRET: "${google_client_secret}"
       GOOGLE_SITE_VERIFICATION_CODE: "${google_site_verification_code}"
+      AWS_DEFAULT_REGION: "${aws_default_region}"
       AWS_ACCESS_KEY_ID: "${aws_access_key_id}"
       AWS_SECRET_ACCESS_KEY: "${aws_secret_access_key}"
       DCC_DASHBOARD_HOST: "${dcc_dashboard_host}"

--- a/install_bootstrap
+++ b/install_bootstrap
@@ -370,6 +370,7 @@ while [[ "${run_boardwalk^^}" != 'Y' &&  "${run_boardwalk^^}" != 'N' ]] ; do
 "PROJECT_NAME":"${project_name}",
 "CONTACT_EMAIL":"${contact_email}",
 "EMAIL_WHITELIST_NAME":"${email_whitelist_name}",
+"REFRESH_TOKEN_ENCRYPT_KEY":"${refresh_token_encrypt_key}",
 "DCC_DASHBOARD_HOST":"${dcc_dashboard_host}",
 "DCC_DASHBOARD_PROTOCOL":"${dcc_dashboard_protocol}",
 "DCC_DASHBOARD_SERVICE":"${dcc_dashboard_service}",

--- a/install_bootstrap
+++ b/install_bootstrap
@@ -47,7 +47,7 @@ function check_for_repo {
 }
 
 function generate_password {
-    tr -cd '[:alnum:]' < /dev/urandom | fold -w30 | head -n1
+    tr -cd '[:alnum:]' < /dev/urandom | fold -w32 | head -n1
 }
 
 # Ask the user a question and save the answer.

--- a/install_bootstrap
+++ b/install_bootstrap
@@ -283,7 +283,7 @@ while [[ "${run_boardwalk^^}" != 'Y' &&  "${run_boardwalk^^}" != 'N' ]] ; do
         # AWS questions            #
         ############################
         aws_default_region='aws_default_region'
-        ask_question "What is your AWS Default Region?" "$AWS_DEFAULT_REGION" "AWS Default Region" $aws_default_region
+        ask_question "What is your AWS region?" "$AWS_DEFAULT_REGION" "AWS region" $aws_default_region
 
         aws_access_key_id='aws_access_key_id'
         ask_question "What is your AWS Access Key ID?" "$AWS_ACCESS_KEY_ID" "AWS Key name" $aws_access_key_id

--- a/install_bootstrap
+++ b/install_bootstrap
@@ -282,6 +282,9 @@ while [[ "${run_boardwalk^^}" != 'Y' &&  "${run_boardwalk^^}" != 'N' ]] ; do
         ############################
         # AWS questions            #
         ############################
+        aws_default_region='aws_default_region'
+        ask_question "What is your AWS Default Region?" "$AWS_DEFAULT_REGION" "AWS Default Region" $aws_default_region
+
         aws_access_key_id='aws_access_key_id'
         ask_question "What is your AWS Access Key ID?" "$AWS_ACCESS_KEY_ID" "AWS Key name" $aws_access_key_id
 
@@ -364,6 +367,7 @@ while [[ "${run_boardwalk^^}" != 'Y' &&  "${run_boardwalk^^}" != 'N' ]] ; do
         cat > boardwalk_launcher_config/boardwalk.config <<CONFIG
 {
 "AZUL_S3_BUCKET":"${azul_s3_bucket}",
+"AWS_DEFAULT_REGION":"${aws_default_region}",
 "AWS_ACCESS_KEY_ID":"${aws_access_key_id}",
 "AWS_SECRET_ACCESS_KEY":"${aws_secret_access_key}",
 "DATABASE_URL":"${database_url}",


### PR DESCRIPTION
A few small issues are wrapped up into this PR.

1. The refresh token encrypt key wasn't actually making it all the way through the deployment. This was fixed in 604e46c.
2. To do the encryption, the key needed to be 32 bits long. Fixed in 24b4f33.
3. AWS environment vars and config needed to be accessible to dashboard. This is addressed in 75a7b5d and 2192b14.

These changes are necessary for https://github.com/DataBiosphere/cgp-dashboard/pull/58