### PR TITLE
Corrected paragraph explaining role of Google Client and Secret (fixes #73)

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,8 +214,9 @@ what to put for each step.
    used only for development.
 
 1. Provide the Google Client ID and Client Secret you got from the
-   OAuth2 app. You will also be asked for a Google site verfication
-   code. For this field you can just enter `NONE`.
+   OAuth2 app. Instructions on how to set this up can be found on the [Boardwalk deployment page](boardwalk/README.md#deployment). Also, enter
+   your Google site verfication code if you have one, otherwise enter
+   `NONE`.
 
 1. The [S3 bucket you created earlier](#makebucket) is what you should
    use for this next step. Provide the name you assigned to the bucket,

--- a/README.md
+++ b/README.md
@@ -213,9 +213,9 @@ what to put for each step.
 1. The elasticsearch instance domain can be one that is prexisting if
    used only for development.
 
-1. You need a Google Client ID and Client Secret to create a Google
-   OAuth2 app during installation. Instructions to set this up can be
-   found on the [Boardwalk deployment page](boardwalk/README.md#deployment).The OAuth2 app will enable users to log in with a Google account
+1. Provide the a Google Client ID and Client Secret you got from the
+   OAuth2 app. Instructions to set this up can be
+   found on the [Boardwalk deployment page](boardwalk/README.md#deployment).That will enable user to log in with a Google account
    (username + pwd) to work with access-controlled data if needed.
    Log-in is not necessary in order to export non-access-controlled
    metadata from _Boardwalk_ to Broad's FireCloud.

--- a/README.md
+++ b/README.md
@@ -214,14 +214,8 @@ what to put for each step.
    used only for development.
 
 1. Provide the Google Client ID and Client Secret you got from the
-   OAuth2 app. Instructions to set this up can be
-   found on the [Boardwalk deployment page](boardwalk/README.md#deployment).That will enable user to log in with a Google account
-   (username + pwd) to work with access-controlled data if needed.
-   Log-in is not necessary in order to export non-access-controlled
-   metadata from _Boardwalk_ to Broad's FireCloud.
-
-   You will also be asked for a Google site verfication code. For this
-   field you can just enter `NONE`.
+   OAuth2 app. You will also be asked for a Google site verfication
+   code. For this field you can just enter `NONE`.
 
 1. The [S3 bucket you created earlier](#makebucket) is what you should
    use for this next step. Provide the name you assigned to the bucket,

--- a/README.md
+++ b/README.md
@@ -213,12 +213,12 @@ what to put for each step.
 1. The elasticsearch instance domain can be one that is prexisting if
    used only for development.
 
-1. Next you will need a Google Client ID and Client secret. If you
-   missed it before, instructions to set this up are found on the
-   [Boardwalk deployment page](boardwalk/README.md#deployment).
-   _Boardwalk_ has functionality to export metadata to Broad's
-   FireCloud. In order to use it you need to provide your Google Cloud
-   Platform credentials.
+1. You need a Google Client ID and Client Secret to create a Google
+   OAuth2 app during installation. Instructions to set this up can be
+   found on the [Boardwalk deployment page](boardwalk/README.md#deployment).The OAuth2 app will enable users to log in with a Google account
+   (username + pwd) to work with access-controlled data if needed.
+   Log-in is not necessary in order to export non-access-controlled
+   metadata from _Boardwalk_ to Broad's FireCloud.
 
    You will also be asked for a Google site verfication code. For this
    field you can just enter `NONE`.

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ what to put for each step.
 1. The elasticsearch instance domain can be one that is prexisting if
    used only for development.
 
-1. Provide the a Google Client ID and Client Secret you got from the
+1. Provide the Google Client ID and Client Secret you got from the
    OAuth2 app. Instructions to set this up can be
    found on the [Boardwalk deployment page](boardwalk/README.md#deployment).That will enable user to log in with a Google account
    (username + pwd) to work with access-controlled data if needed.


### PR DESCRIPTION
* Explained that user does not need to be logged in in order to export non-access-controlled data to FireCloud.
* Clarified significance of Google Client and Secret a user needs to provide during installation.
* Removed incorrect statement.