### PR TITLE
Update `integration test` (fixes #77)

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,9 +265,10 @@ containers are running.
 
 ### Confirm Proper Function
 
-To test that all Docker containers are successfully running, you can
-run `cd test && ./integration.sh`. This sends a GET to the configured
-DCC dashboard host and checks whether the response is as expected.
+To test that the required number of Docker containers is successfully
+running execute `cd test && ./integration.sh`. This sends several HTTP-GETs
+to the configured DCC dashboard host and checks whether the responses are
+as expected.
 
 ### Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -265,9 +265,9 @@ containers are running.
 
 ### Confirm Proper Function
 
-To test that everything installed successfully, you can run `cd test &&
-./integration.sh`. This will do an upload and download with core-client
-and check the results.
+To test that all Docker containers are successfully running, you can
+run `cd test && ./integration.sh`. This sends a GET to the configured
+DCC dashboard host and checks whether the response is as expected.
 
 ### Troubleshooting
 

--- a/test/expected_containers
+++ b/test/expected_containers
@@ -1,0 +1,1 @@
+boardwalk_nginx_1 boardwalk_dcc-dashboard-service_1 boardwalk_dcc-dashboard_1 boardwalk_boardwalk_1 login-db core-config-gen core-letsencrypt-nginx-companion core-nginx

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -27,7 +27,7 @@ function check_setup {
     # containers are running.
     [ "${#containers[@]}" -ge $num_containers_exp ] ||\
         (ERROR "Not running the required number of docker containers."\
-		&& exit 1)
+                && exit 1)
 
     for container_expected in "${containers_expected[@]}"; do
         counter=0
@@ -41,7 +41,7 @@ function check_setup {
 
         if [[ "$counter" -eq $num_containers_exp ]]; then
             ERROR "One or more docker containers not running."\
-		&& exit 1
+                && exit 1
         fi
     done
 
@@ -60,7 +60,7 @@ function main {
     curr_dir=$(pwd)
     cd ../boardwalk
     dcc_host=$(grep -o 'dcc_dashboard_service.*' .env | cut -f2- -d=)
-    # Check from environment variable value whether user is white-listed.    
+    # Check from environment variable value whether user is white-listed.
     whitelist_set=$(grep -o 'email_white.*' .env | cut -f2- -d=)
     cd "$curr_dir"
 
@@ -71,7 +71,7 @@ function main {
     # If not 200 write out HTTP status code.
     status_code=$(curl -I -w "%{http_code}" -s -o /dev/null "https://$dcc_host")
     if [[ "$status_code" -ne 200 ]]; then
-	ERROR "HTTP status: $status_code from https://$dcc_host" && exit 1
+        ERROR "HTTP status: $status_code from https://$dcc_host" && exit 1
     fi
 
     # Get status code of response to export functionality.
@@ -84,7 +84,7 @@ function main {
     if [[ "$status_code" -ne 401 ]] && [[ ! -z "$whitelist_set" ]]; then
         ERROR "Status code: $status_code (expected 401) from $url" && exit 1
     elif [[ "$status_code" -ne 200 ]] && [[ "$status_code" -ne 401 ]]; then
-	ERROR "Response returned status code $status_code from $url" && exit 1
+        ERROR "Response returned status code $status_code from $url" && exit 1
     fi
 
     INFO "TEST SUCCEEDED"

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -17,14 +17,17 @@ function check_setup {
 
     # Get array of all required containers from file.
     fname=expected_containers
-    IFS=$'\r\n' GLOBIGNORE='*' command eval  'containers_expected=($(cat $fname))'
+    IFS=$'\r\n' GLOBIGNORE='*'\
+       command eval  'containers_expected=($(cat $fname))'
     containers_expected=($containers_expected)  # cast as array
 
     num_containers_exp="${#containers_expected[@]}"
 
-    # Crude initial test to verify that at least 7 containers are running.
+    # Crude initial test to verify that at least the minimum number of
+    # containers are running.
     [ "${#containers[@]}" -ge $num_containers_exp ] ||\
-        (ERROR "Not running the required number of docker containers." && exit 1)
+        (ERROR "Not running the required number of docker containers."\
+		&& exit 1)
 
     for container_expected in "${containers_expected[@]}"; do
         counter=0
@@ -37,7 +40,8 @@ function check_setup {
         done
 
         if [[ "$counter" -eq $num_containers_exp ]]; then
-            ERROR "One or more docker containers not running." && exit 1
+            ERROR "One or more docker containers not running."\
+		&& exit 1
         fi
     done
 

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -80,7 +80,8 @@ function main {
         ERROR "Did not get expected status code 401 from host $dcc_host" && exit 1
     elif [[ ! "$status_code" == *"200"* ]]\
 	     && [[ ! "$status_code" == *"401"* ]]; then
-	ERROR "Did not get expected status code 200 from host $dcc_host" && exit 1
+	ERROR "Response returned status code $status_code from host $dcc_host"\
+	    && exit 1
     fi
 
     INFO "TEST SUCCEEDED"

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -68,6 +68,12 @@ function main {
     # otherwise it aborts and prints cURL error code to stdout.
     curl -fsS "https://$dcc_host" > /dev/null
 
+    # If not 200 write out HTTP status code.
+    status_code=$(curl -I -w "%{http_code}" -s -o /dev/null "https://$dcc_host")
+    if [[ "$status_code" -ne 200 ]]; then
+	ERROR "HTTP status: $status_code from https://$dcc_host" && exit 1
+    fi
+
     # Get status code of response to export functionality.
     url="https://$dcc_host/api/v1/repository/files/export"
     response=$(curl -sIL "$url")  # no output, just headers, follow redirects
@@ -77,10 +83,10 @@ function main {
     # is expected to return 200; if user is white-listed a 401 is the expected
     # response.
     if [[ ! "$status_code" == *"401"* ]] && [[ ! -z "$whitelist_set" ]]; then
-        ERROR "Did not get expected status code 401 from host $dcc_host" && exit 1
+        ERROR "Did not get expected status code 401 from https://$dcc_host" && exit 1
     elif [[ ! "$status_code" == *"200"* ]]\
 	     && [[ ! "$status_code" == *"401"* ]]; then
-	ERROR "Response returned status code $status_code from host $dcc_host"\
+	ERROR "Response returned status code $status_code from https://$dcc_host"\
 	    && exit 1
     fi
 

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -64,7 +64,11 @@ function main {
     whitelist_set=$(grep -o 'email_white.*' .env | cut -f2- -d=)
     cd "$curr_dir"
 
-    # Get status code of response.
+    # Check if home page is returned. If so it will not output anything,
+    # otherwise it aborts and prints cURL error code to stdout.
+    curl -fsS "https://$dcc_host" > /dev/null
+
+    # Get status code of response to export functionality.
     url="https://$dcc_host/api/v1/repository/files/export"
     response=$(curl -sIL "$url")  # no output, just headers, follow redirects
     status_code=$(echo "$response" | grep 'HTTP.*' | cut -f2- -d " ")

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -48,9 +48,9 @@ function main {
     # hits the DCC Dashboard Host and checks whether it returns a 200
     # status code.
 
-    check_setup
     cd "$(dirname "${BASH_SOURCE[0]}")"
     LOG_LEVEL_ALL
+    check_setup
 
     # Get name of the DCC Dashboard Host.
     curr_dir=$(pwd)

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -1,11 +1,46 @@
 #!/usr/bin/env bash
-set -e
+
+set -e  # exit if return is non-zero
+# Start logging.
 source $(dirname $( realpath ${BASH_SOURCE[0]} ) )/lib/b-log.sh
 
 function check_setup {
-    [[ $(sudo docker ps | tail -n +2 | wc -l) -ge 7 ]] || (echo "the required docker containers don't seem to be running" && exit 1)
-    # TODO count number of dashboard containers
-    # TODO more rigorous checking
+
+    # This function exits the script if:
+    #   (i) the number of running Docker is less than
+    #       the required number of containers
+    #   (ii) not all exact names of required Docker containers
+    #        match all names in the list of running Docker containers
+
+    # Get array of running containers.
+    containers=($(sudo docker ps | tail -n +2 | awk ' {print $NF} '))
+
+    # Get array of all necessary containers from file.
+    fname=~/cgp-deployment/test/expected_containers
+    IFS=$'\r\n' GLOBIGNORE='*' command eval  'containers_expected=($(cat $fname))'
+    containers_expected=($containers_expected)  # cast as array
+
+    num_containers_exp="${#containers_expected[@]}"
+
+    # Crude initial test to verify that at least 7 containers are running.
+    [ "${#containers[@]}" -ge $num_containers_exp ] ||\
+        (ERROR "Not running the required number of docker containers." && exit 1)
+
+    for container_expected in "${containers_expected[@]}"; do
+        counter=0
+        for container in "${containers[@]}"; do
+            if [[ $container_expected = $container ]]; then
+                continue
+            else
+                counter=$((counter+1))
+            fi
+        done
+
+        if [[ "$counter" -eq $num_containers_exp ]]; then
+            ERROR "One or more docker containers not running." && exit 1
+        fi
+    done
+
 }
 
 function main {
@@ -15,33 +50,33 @@ function main {
 
     [[ -d outputs ]] && sudo rm -rf outputs && INFO "deleted old outputs"
 
-    access_token=$(../redwood/cli/bin/redwood token create)
-    INFO "generated testing access token: ${access_token}"
+    # access_token=$(../redwood/cli/bin/redwood token create)
+    # INFO "generated testing access token: ${access_token}"
 
-    redwood_endpoint=$(cat ../redwood/.env | grep 'base_url=' | sed 's/[^=]*=//')
-    INFO "got redwood endpoint from dcc-ops/redwood/.env: ${redwood_endpoint}"
+    # redwood_endpoint=$(cat ../redwood/.env | grep 'base_url=' | sed 's/[^=]*=//')
+    # INFO "got redwood endpoint from dcc-ops/redwood/.env: ${redwood_endpoint}"
 
-    INFO "doing upload with $(pwd)/manifest.tsv"
-    sudo docker run --rm -it -e ACCESS_TOKEN=${access_token} -e REDWOOD_ENDPOINT=${redwood_endpoint} \
-         -v $(pwd)/manifest.tsv:/dcc/manifest.tsv -v $(pwd)/samples:/samples -v $(pwd)/outputs:/outputs \
-         quay.io/ucsc_cgl/core-client:1.1.0-alpha spinnaker-upload --skip-submit --force-upload /dcc/manifest.tsv
+    # INFO "doing upload with $(pwd)/manifest.tsv"
+    # sudo docker run --rm -it -e ACCESS_TOKEN=${access_token} -e REDWOOD_ENDPOINT=${redwood_endpoint} \
+    #      -v $(pwd)/manifest.tsv:/dcc/manifest.tsv -v $(pwd)/samples:/samples -v $(pwd)/outputs:/outputs \
+    #      quay.io/ucsc_cgl/core-client:1.1.0-alpha spinnaker-upload --skip-submit --force-upload /dcc/manifest.tsv
 
-    object_id=$(cat outputs/receipt.tsv | tail -n +3 | head -n 1 | cut -f 20)
-    bundle_id=$(cat outputs/receipt.tsv | tail -n +3 | head -n 1 | cut -f 19)
-    INFO "the uploaded bundle with id ${bundle_id} has metadata.json with object id ${object_id}"
+    # object_id=$(cat outputs/receipt.tsv | tail -n +3 | head -n 1 | cut -f 20)
+    # bundle_id=$(cat outputs/receipt.tsv | tail -n +3 | head -n 1 | cut -f 19)
+    # INFO "the uploaded bundle with id ${bundle_id} has metadata.json with object id ${object_id}"
 
-    INFO "downloading metadata.json with object id ${object_id}"
-    sudo mkdir outputs/test_download
-    sudo docker run --rm -it -e ACCESS_TOKEN=${access_token} -e REDWOOD_ENDPOINT=${redwood_endpoint} \
-         -v $(pwd)/outputs:/outputs quay.io/ucsc_cgl/core-client:1.1.0-alpha download ${object_id} /outputs/test_download
+    # INFO "downloading metadata.json with object id ${object_id}"
+    # sudo mkdir outputs/test_download
+    # sudo docker run --rm -it -e ACCESS_TOKEN=${access_token} -e REDWOOD_ENDPOINT=${redwood_endpoint} \
+    #      -v $(pwd)/outputs:/outputs quay.io/ucsc_cgl/core-client:1.1.0-alpha download ${object_id} /outputs/test_download
 
-    [[ ! -f outputs/test_download/${bundle_id}/metadata.json ]] && printf "%s: no such file" "outputs/test_download/${bundle_id}/metadata.json" | FATAL && exit 1
+    # [[ ! -f outputs/test_download/${bundle_id}/metadata.json ]] && printf "%s: no such file" "outputs/test_download/${bundle_id}/metadata.json" | FATAL && exit 1
 
-    sudo rm -rf outputs
+    # sudo rm -rf outputs
 
-    # TODO: run indexer, etc.
+    # # TODO: run indexer, etc.
 
-    INFO "TEST SUCCESS"
+    INFO "TEST SUCCEEDED"
 }
 
 main "$@"

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -47,7 +47,7 @@ function main {
     # This tests whether all Docker containers are installed and then
     # hits the DCC Dashboard Host and checks whether it returns a 200
     # status code.
-    
+
     check_setup
     cd "$(dirname "${BASH_SOURCE[0]}")"
     LOG_LEVEL_ALL
@@ -63,9 +63,9 @@ function main {
 
     status_code=$(echo "$response" | grep 'HTTP.*' | cut -f2- -d " ")
     if [[ ! "$status_code" == *"200"* ]]; then
-	ERROR "Did not get status code 200 from host $dcc_host" && exit 1
+        ERROR "Did not get status code 200 from host $dcc_host" && exit 1
     fi
-    
+
     INFO "TEST SUCCEEDED"
 }
 


### PR DESCRIPTION
I made changes to `integration.sh`. When invoked it checks whether all required containers are running, and send a simple GET to the deployed DCC dashboard host and checks whether response status code is 200. The relevant passage in the `README` has been updated.